### PR TITLE
Generalize Protocol Types for Portability

### DIFF
--- a/channel_scanner.cpp
+++ b/channel_scanner.cpp
@@ -41,7 +41,7 @@ IChannelScanner::ScanResult RealChannelScanner::scan(uint8_t start_channel)
         probe_header.msg_type       = MessageType::CHANNEL_SCAN_PROBE;
         probe_header.sender_node_id = my_node_id_;
         probe_header.sender_type    = my_node_type_;
-        probe_header.dest_node_id   = NodeId::HUB;
+        probe_header.dest_node_id   = ReservedIds::HUB;
         probe_header.sequence_number = 0;
         probe_header.timestamp_ms    = 0; // Not critical for probe
 

--- a/espnow_manager.cpp
+++ b/espnow_manager.cpp
@@ -29,11 +29,11 @@ EspNow &EspNow::instance()
 
     static RealWiFiHAL wifi_hal;
     static RealTxStateMachine tx_fsm;
-    static RealChannelScanner scanner(wifi_hal, *message_codec, NodeId::HUB, NodeType::HUB);
+    static RealChannelScanner scanner(wifi_hal, *message_codec, ReservedIds::HUB, ReservedTypes::HUB);
 
     static auto tx_manager = std::make_unique<RealTxManager>(tx_fsm, scanner, wifi_hal, *message_codec);
 
-    static auto heartbeat_mgr = std::make_unique<RealHeartbeatManager>(*tx_manager, *peer_manager, *message_codec, NodeId::HUB);
+    static auto heartbeat_mgr = std::make_unique<RealHeartbeatManager>(*tx_manager, *peer_manager, *message_codec, ReservedIds::HUB);
     static auto pairing_mgr = std::make_unique<RealPairingManager>(*tx_manager, *peer_manager, *message_codec);
     static auto message_router = std::make_unique<RealMessageRouter>(*peer_manager, *tx_manager, *heartbeat_mgr, *pairing_mgr, *message_codec);
 

--- a/heartbeat_manager.cpp
+++ b/heartbeat_manager.cpp
@@ -28,7 +28,7 @@ esp_err_t RealHeartbeatManager::init(uint32_t interval_ms, NodeType type)
     interval_ms_ = interval_ms;
     my_type_ = type;
 
-    if (my_type_ != NodeType::HUB && interval_ms_ > 0)
+    if (my_type_ != ReservedTypes::HUB && interval_ms_ > 0)
     {
         timer_ = xTimerCreate("heartbeat", pdMS_TO_TICKS(interval_ms_), pdTRUE, this, timer_cb);
         if (timer_ == nullptr) return ESP_FAIL;
@@ -83,7 +83,7 @@ void RealHeartbeatManager::handle_request(NodeId sender_id, const uint8_t *mac, 
 void RealHeartbeatManager::send_heartbeat()
 {
     TxPacket tx_packet;
-    if (!peer_mgr_.find_mac(NodeId::HUB, tx_packet.dest_mac))
+    if (!peer_mgr_.find_mac(ReservedIds::HUB, tx_packet.dest_mac))
     {
         const uint8_t broadcast_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
         memcpy(tx_packet.dest_mac, broadcast_mac, 6);
@@ -93,7 +93,7 @@ void RealHeartbeatManager::send_heartbeat()
     heartbeat.header.msg_type       = MessageType::HEARTBEAT;
     heartbeat.header.sender_node_id = my_id_;
     heartbeat.header.sender_type    = my_type_;
-    heartbeat.header.dest_node_id   = NodeId::HUB;
+    heartbeat.header.dest_node_id   = ReservedIds::HUB;
     heartbeat.header.sequence_number = 0;
     heartbeat.uptime_ms             = esp_timer_get_time() / 1000;
 

--- a/host_test/espnow_facade/main/test_espnow_facade.cpp
+++ b/host_test/espnow_facade/main/test_espnow_facade.cpp
@@ -10,6 +10,7 @@
 #include "mock_heartbeat_manager.hpp"
 #include "mock_pairing_manager.hpp"
 #include "mock_channel_scanner.hpp"
+#include "mock_message_router.hpp"
 
 TEST_CASE("EspNow can be instantiated with mocks", "[espnow]")
 {
@@ -19,8 +20,9 @@ TEST_CASE("EspNow can be instantiated with mocks", "[espnow]")
     auto mc = std::make_unique<MockMessageCodec>();
     auto hm = std::make_unique<MockHeartbeatManager>();
     auto pam = std::make_unique<MockPairingManager>();
+    auto mr = std::make_unique<MockMessageRouter>();
 
-    EspNow espnow(std::move(pm), std::move(tx), cs.get(), std::move(mc), std::move(hm), std::move(pam));
+    EspNow espnow(std::move(pm), std::move(tx), cs.get(), std::move(mc), std::move(hm), std::move(pam), std::move(mr));
 
     TEST_ASSERT_TRUE(true);
 }

--- a/host_test/mocks/mock_channel_scanner.hpp
+++ b/host_test/mocks/mock_channel_scanner.hpp
@@ -9,4 +9,5 @@ public:
     {
         return {start_channel, false};
     }
+    inline void update_node_info(NodeId id, NodeType type) override {}
 };

--- a/host_test/mocks/mock_message_router.hpp
+++ b/host_test/mocks/mock_message_router.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "espnow_interfaces.hpp"
+
+class MockMessageRouter : public IMessageRouter
+{
+public:
+    inline void handle_packet(const RxPacket &packet) override {}
+    inline bool should_dispatch_to_worker(MessageType type) override { return false; }
+    inline void set_app_queue(QueueHandle_t app_queue) override {}
+    inline void set_node_info(NodeId id, NodeType type) override {}
+};

--- a/host_test/peer_manager/main/test_peer_manager.cpp
+++ b/host_test/peer_manager/main/test_peer_manager.cpp
@@ -7,6 +7,20 @@ extern "C" {
 }
 #include <cstring>
 
+enum class TestNodeId : NodeId
+{
+    TEST_HUB      = 1,
+    TEST_SENSOR_A = 10,
+    TEST_SENSOR_B = 11,
+    NON_EXISTENT  = 99
+};
+
+enum class TestNodeType : NodeType
+{
+    HUB    = 1,
+    SENSOR = 2
+};
+
 TEST_CASE("PeerManager can add and find peers", "[peer_manager]")
 {
     esp_now_add_peer_IgnoreAndReturn(ESP_OK);
@@ -17,11 +31,11 @@ TEST_CASE("PeerManager can add and find peers", "[peer_manager]")
     RealPeerManager pm(storage);
 
     uint8_t mac1[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-    esp_err_t err   = pm.add(NodeId::WATER_TANK, mac1, 1, NodeType::SENSOR);
+    esp_err_t err   = pm.add(TestNodeId::TEST_SENSOR_A, mac1, 1, TestNodeType::SENSOR);
     TEST_ASSERT_EQUAL(ESP_OK, err);
 
     uint8_t found_mac[6];
-    TEST_ASSERT_TRUE(pm.find_mac(NodeId::WATER_TANK, found_mac));
+    TEST_ASSERT_TRUE(pm.find_mac(TestNodeId::TEST_SENSOR_A, found_mac));
     TEST_ASSERT_EQUAL_MEMORY(mac1, found_mac, 6);
 }
 
@@ -36,14 +50,14 @@ TEST_CASE("PeerManager handles LRU", "[peer_manager]")
 
     for (int i = 0; i < MAX_PEERS; ++i) {
         uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, (uint8_t)i};
-        pm.add((NodeId)(100 + i), mac, 1, NodeType::SENSOR);
+        pm.add((NodeId)(100 + i), mac, 1, (NodeType)TestNodeType::SENSOR);
     }
 
     TEST_ASSERT_EQUAL(MAX_PEERS, pm.get_all().size());
 
     // Add one more, oldest (ID 100) should be removed
     uint8_t mac_new[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    pm.add((NodeId)200, mac_new, 1, NodeType::SENSOR);
+    pm.add((NodeId)200, mac_new, 1, (NodeType)TestNodeType::SENSOR);
 
     TEST_ASSERT_EQUAL(MAX_PEERS, pm.get_all().size());
     TEST_ASSERT_FALSE(pm.find_mac((NodeId)100, nullptr));
@@ -60,9 +74,9 @@ TEST_CASE("PeerManager detects offline peers", "[peer_manager]")
     RealPeerManager pm(storage);
 
     uint8_t mac[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-    pm.add(NodeId::WATER_TANK, mac, 1, NodeType::SENSOR, 1000); // 1s heartbeat
+    pm.add(TestNodeId::TEST_SENSOR_A, mac, 1, TestNodeType::SENSOR, 1000); // 1s heartbeat
 
-    pm.update_last_seen(NodeId::WATER_TANK, 10000);
+    pm.update_last_seen(TestNodeId::TEST_SENSOR_A, 10000);
 
     // Offline threshold is 2.5 * 1000 = 2500ms.
     // So at 12501ms it should be offline.
@@ -72,7 +86,7 @@ TEST_CASE("PeerManager detects offline peers", "[peer_manager]")
 
     offline = pm.get_offline(12501);
     TEST_ASSERT_EQUAL(1, offline.size());
-    TEST_ASSERT_EQUAL(NodeId::WATER_TANK, offline[0]);
+    TEST_ASSERT_EQUAL(to_node_id(TestNodeId::TEST_SENSOR_A), offline[0]);
 }
 
 TEST_CASE("PeerManager persists to storage on add", "[peer_manager]")
@@ -85,12 +99,12 @@ TEST_CASE("PeerManager persists to storage on add", "[peer_manager]")
 
     // Add a peer
     uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    pm.add(NodeId::WATER_TANK, mac, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac, 1, TestNodeType::SENSOR);
 
     // Check if it was saved
     TEST_ASSERT_TRUE(storage.save_called);
     TEST_ASSERT_EQUAL(1, storage.saved_peers.size());
-    TEST_ASSERT_EQUAL(NodeId::WATER_TANK, storage.saved_peers[0].node_id);
+    TEST_ASSERT_EQUAL(to_node_id(TestNodeId::TEST_SENSOR_A), storage.saved_peers[0].node_id);
     TEST_ASSERT_EQUAL_MEMORY(mac, storage.saved_peers[0].mac, 6);
 }
 
@@ -103,9 +117,9 @@ TEST_CASE("PeerManager loads peers from storage", "[peer_manager]")
     // Pre populate storage
     PersistentPeer p1;
     memcpy(p1.mac, "\xAA\xBB\xCC\xDD\xEE\xFF", 6);
-    p1.node_id               = NodeId::WATER_TANK;
+    p1.node_id               = to_node_id(TestNodeId::TEST_SENSOR_A);
     p1.channel               = 6;
-    p1.type                  = NodeType::SENSOR;
+    p1.type                  = to_node_type(TestNodeType::SENSOR);
     p1.paired                = true;
     p1.heartbeat_interval_ms = 5000;
 
@@ -126,7 +140,7 @@ TEST_CASE("PeerManager loads peers from storage", "[peer_manager]")
 
     // Check peer
     uint8_t found_mac[6];
-    TEST_ASSERT_TRUE(pm.find_mac(NodeId::WATER_TANK, found_mac));
+    TEST_ASSERT_TRUE(pm.find_mac(TestNodeId::TEST_SENSOR_A, found_mac));
     TEST_ASSERT_EQUAL_MEMORY(p1.mac, found_mac, 6);
 }
 
@@ -141,18 +155,18 @@ TEST_CASE("PeerManager updates existing peer", "[peer_manager]")
 
     // Add peer
     uint8_t mac_old[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-    pm.add(NodeId::WATER_TANK, mac_old, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac_old, 1, TestNodeType::SENSOR);
 
     // Change mac from same peerId (simulating changin a vroken device with a new one)
     uint8_t mac_new[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    pm.add(NodeId::WATER_TANK, mac_new, 1, NodeType::SENSOR); // Same NodeId!
+    pm.add(TestNodeId::TEST_SENSOR_A, mac_new, 1, TestNodeType::SENSOR); // Same NodeId!
 
     // Must be only one peer, not duplicated
     TEST_ASSERT_EQUAL(1, pm.get_all().size());
 
     // MAC must be the new one
     uint8_t found_mac[6];
-    pm.find_mac(NodeId::WATER_TANK, found_mac);
+    pm.find_mac(TestNodeId::TEST_SENSOR_A, found_mac);
     TEST_ASSERT_EQUAL_MEMORY(mac_new, found_mac, 6);
 }
 
@@ -166,18 +180,18 @@ TEST_CASE("PeerManager removes peer", "[peer_manager]")
 
     // Add a peer
     uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    pm.add(NodeId::WATER_TANK, mac, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac, 1, TestNodeType::SENSOR);
 
     // Check if it was saved
     TEST_ASSERT_EQUAL(1, pm.get_all().size());
 
     // Remove the peer
-    esp_err_t err = pm.remove(NodeId::WATER_TANK);
+    esp_err_t err = pm.remove(TestNodeId::TEST_SENSOR_A);
     TEST_ASSERT_EQUAL(ESP_OK, err);
 
     // Check if it was removed
     TEST_ASSERT_EQUAL(0, pm.get_all().size());
-    TEST_ASSERT_FALSE(pm.find_mac(NodeId::WATER_TANK, nullptr));
+    TEST_ASSERT_FALSE(pm.find_mac(TestNodeId::TEST_SENSOR_A, nullptr));
 }
 
 TEST_CASE("PeerManager returns error removing non-existent peer", "[peer_manager]")
@@ -190,13 +204,13 @@ TEST_CASE("PeerManager returns error removing non-existent peer", "[peer_manager
 
     // Add a peer
     uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    pm.add(NodeId::WATER_TANK, mac, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac, 1, TestNodeType::SENSOR);
 
     // Check if it was saved
     TEST_ASSERT_EQUAL(1, pm.get_all().size());
 
     // Try to remove non-existent peer
-    esp_err_t err = pm.remove(NodeId::SOLAR_SENSOR);
+    esp_err_t err = pm.remove(TestNodeId::TEST_SENSOR_B);
     TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, err);
 }
 
@@ -210,8 +224,8 @@ TEST_CASE("PeerManager saves on every add", "[peer_manager]")
     // Save two peers
     uint8_t mac1[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     uint8_t mac2[6] = {0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
-    pm.add(NodeId::WATER_TANK, mac1, 1, NodeType::SENSOR);
-    pm.add(NodeId::SOLAR_SENSOR, mac2, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac1, 1, TestNodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_B, mac2, 1, TestNodeType::SENSOR);
 
     // Should have been saved twice
     TEST_ASSERT_EQUAL(2, storage.save_call_count);
@@ -231,20 +245,20 @@ TEST_CASE("PeerManager moves accessed peer to front (LRU)", "[peer_manager]")
     uint8_t mac2[6] = {0x02, 0x02, 0x02, 0x02, 0x02, 0x02};
     uint8_t mac3[6] = {0x03, 0x03, 0x03, 0x03, 0x03, 0x03};
 
-    pm.add(NodeId::HUB, mac1, 1, NodeType::HUB);
-    pm.add(NodeId::WATER_TANK, mac2, 1, NodeType::SENSOR);
-    pm.add(NodeId::SOLAR_SENSOR, mac3, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_HUB, mac1, 1, TestNodeType::HUB);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac2, 1, TestNodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_B, mac3, 1, TestNodeType::SENSOR);
 
     auto peers = pm.get_all();
     // The last peer add must be first on vector list
-    TEST_ASSERT_EQUAL(NodeId::SOLAR_SENSOR, peers[0].node_id);
+    TEST_ASSERT_EQUAL(to_node_id(TestNodeId::TEST_SENSOR_B), peers[0].node_id);
 
     // Re adding HUB should move it to the front
-    pm.add(NodeId::HUB, mac1, 1, NodeType::HUB);
+    pm.add(TestNodeId::TEST_HUB, mac1, 1, TestNodeType::HUB);
 
     peers = pm.get_all();
     // HUB must be the first
-    TEST_ASSERT_EQUAL(NodeId::HUB, peers[0].node_id);
+    TEST_ASSERT_EQUAL(to_node_id(TestNodeId::TEST_HUB), peers[0].node_id);
 }
 
 TEST_CASE("PeerManager updates peer channel", "[peer_manager]")
@@ -257,10 +271,10 @@ TEST_CASE("PeerManager updates peer channel", "[peer_manager]")
 
     // Add a peer with channel 1
     uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    pm.add(NodeId::WATER_TANK, mac, 1, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac, 1, TestNodeType::SENSOR);
 
     // Change channel to 6 but same MAC
-    pm.add(NodeId::WATER_TANK, mac, 6, NodeType::SENSOR);
+    pm.add(TestNodeId::TEST_SENSOR_A, mac, 6, TestNodeType::SENSOR);
 
     auto peers = pm.get_all();
     TEST_ASSERT_EQUAL(1, peers.size());
@@ -284,11 +298,11 @@ TEST_CASE("PeerManager handles MAC update failure gracefully", "[peer_manager]")
 
     // First add with ESP_OK return
     uint8_t mac_old[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
-    pm.add(NodeId::WATER_TANK, mac_old, 1, NodeType::SENSOR); // OK
+    pm.add(TestNodeId::TEST_SENSOR_A, mac_old, 1, TestNodeType::SENSOR); // OK
 
     // Second add with ESP_FAIL simulating internal espnow criver error
     uint8_t mac_new[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    esp_err_t err      = pm.add(NodeId::WATER_TANK, mac_new, 1, NodeType::SENSOR); // FAIL
+    esp_err_t err      = pm.add(TestNodeId::TEST_SENSOR_A, mac_new, 1, TestNodeType::SENSOR); // FAIL
 
     // Error must be ESP_FAIL
     TEST_ASSERT_EQUAL(ESP_FAIL, err);
@@ -297,7 +311,7 @@ TEST_CASE("PeerManager handles MAC update failure gracefully", "[peer_manager]")
 
     // Old peer must exist and MAC must be the old one
     uint8_t found_mac[6];
-    TEST_ASSERT_TRUE(pm.find_mac(NodeId::WATER_TANK, found_mac));
+    TEST_ASSERT_TRUE(pm.find_mac(TestNodeId::TEST_SENSOR_A, found_mac));
     TEST_ASSERT_EQUAL_MEMORY(mac_old, found_mac, 6);
 }
 
@@ -317,7 +331,7 @@ TEST_CASE("PeerManager handles storage save failure", "[peer_manager]")
     RealPeerManager pm(storage);
 
     uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    esp_err_t err  = pm.add(NodeId::WATER_TANK, mac, 1, NodeType::SENSOR);
+    esp_err_t err  = pm.add(TestNodeId::TEST_SENSOR_A, mac, 1, TestNodeType::SENSOR);
 
     // pm.add with save (to storage) failure, still returns ESP_OK
     TEST_ASSERT_EQUAL(ESP_OK, err);

--- a/host_test/peer_manager/sdkconfig.defaults
+++ b/host_test/peer_manager/sdkconfig.defaults
@@ -2,3 +2,5 @@
 # Espressif IoT Development Framework (ESP-IDF) 5.5.1 Project Minimal Configuration
 #
 CONFIG_IDF_TARGET="linux"
+CONFIG_LOG_DEFAULT_LEVEL_NONE=y
+CONFIG_LOG_DEFAULT_LEVEL=0

--- a/include/app_protocol_types.hpp
+++ b/include/app_protocol_types.hpp
@@ -1,0 +1,83 @@
+#pragma once
+#include "protocol_messages.hpp"
+#include "protocol_types.hpp"
+
+#pragma pack(push, 1)
+
+/**
+ * @brief Application-specific Node IDs for the Irrigation project.
+ * These are mapped to the generic NodeId (uint8_t).
+ */
+enum class IrrigationNodeId : NodeId
+{
+    WATER_TANK   = 5,
+    SOLAR_SENSOR = 7,
+    PUMP_CONTROL = 10,
+    WEATHER      = 12,
+};
+
+/**
+ * @brief Application-specific Node Types for the Irrigation project.
+ */
+enum class IrrigationNodeType : NodeType
+{
+    SENSOR   = 2,
+    ACTUATOR = 3,
+};
+
+/**
+ * @brief Application-specific Payload Types for the Irrigation project.
+ */
+enum class IrrigationPayloadType : PayloadType
+{
+    WATER_LEVEL_REPORT     = 0x01,
+    SOLAR_SENSOR_REPORT    = 0x02,
+    WEATHER_REPORT         = 0x03,
+    LOAD_CONTROLLER_STATUS = 0x04,
+};
+
+enum class UsQuality : uint8_t
+{
+    OK,      /**< Measurement is reliable and within expected parameters. */
+    WEAK,    /**< Measurement is valid but may have reduced accuracy. */
+    INVALID, /**< Measurement is unreliable and should be discarded. */
+};
+
+enum class UsFailure : uint8_t
+{
+    NONE,          /**< No failure occurred. */
+    TIMEOUT,       /**< The echo pulse was not received within the timeout period. */
+    HW_ERROR,      /**< A hardware-level error, such as a stuck ECHO pin. */
+    INVALID_PULSE, /**< The measured pulse corresponds to a distance outside the valid
+                      range. */
+    HIGH_VARIANCE, /**< The variance among valid pings is too high, indicating
+                      instability. */
+};
+
+struct WaterLevelReport
+{
+    MessageHeader header;
+    uint16_t level_permille;
+    float distance_cm;
+    uint16_t battery_mv;
+    UsQuality quality;
+    UsFailure failure;
+    bool float_switch_is_full;
+    bool backup_mode_active;
+};
+
+struct SolarSensorReport
+{
+    MessageHeader header;
+    uint16_t voltage_mv;
+    uint16_t current_ma;
+    uint16_t power_mw;
+};
+
+#pragma pack(pop)
+
+// Validações de tamanho para garantir que nenhum payload exceda o limite do ESP-NOW
+static_assert(sizeof(WaterLevelReport) <= MAX_PAYLOAD_SIZE,
+              "WaterLevelReport payload is too large");
+static_assert(sizeof(SolarSensorReport) <= MAX_PAYLOAD_SIZE,
+              "SolarSensorReport payload is too large");

--- a/include/channel_scanner.hpp
+++ b/include/channel_scanner.hpp
@@ -7,6 +7,8 @@ class RealChannelScanner : public IChannelScanner
 public:
     RealChannelScanner(IWiFiHAL &wifi_hal, IMessageCodec &message_codec, NodeId my_node_id, NodeType my_node_type);
 
+    using IChannelScanner::update_node_info;
+
     ScanResult scan(uint8_t start_channel) override;
     void update_node_info(NodeId id, NodeType type) override;
 

--- a/include/espnow_interfaces.hpp
+++ b/include/espnow_interfaces.hpp
@@ -14,13 +14,41 @@ class IPeerManager
 public:
     virtual ~IPeerManager() = default;
     virtual esp_err_t add(NodeId id, const uint8_t *mac, uint8_t channel, NodeType type, uint32_t heartbeat_interval_ms = 0) = 0;
-    virtual esp_err_t remove(NodeId id)                                                 = 0;
-    virtual bool find_mac(NodeId id, uint8_t *mac)                                      = 0;
-    virtual std::vector<PeerInfo> get_all()                                             = 0;
-    virtual std::vector<NodeId> get_offline(uint64_t now_ms)                            = 0;
-    virtual void update_last_seen(NodeId id, uint64_t now_ms)                           = 0;
-    virtual esp_err_t load_from_storage(uint8_t &wifi_channel)                         = 0;
-    virtual void persist(uint8_t wifi_channel)                                         = 0;
+
+    template <typename T1, typename T2,
+              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    esp_err_t add(T1 id, const uint8_t *mac, uint8_t channel, T2 type, uint32_t heartbeat_interval_ms = 0)
+    {
+        return add(static_cast<NodeId>(id), mac, channel, static_cast<NodeType>(type), heartbeat_interval_ms);
+    }
+
+    virtual esp_err_t remove(NodeId id) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    esp_err_t remove(T id)
+    {
+        return remove(static_cast<NodeId>(id));
+    }
+
+    virtual bool find_mac(NodeId id, uint8_t *mac) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    bool find_mac(T id, uint8_t *mac)
+    {
+        return find_mac(static_cast<NodeId>(id), mac);
+    }
+
+    virtual std::vector<PeerInfo> get_all()                  = 0;
+    virtual std::vector<NodeId> get_offline(uint64_t now_ms) = 0;
+
+    virtual void update_last_seen(NodeId id, uint64_t now_ms) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    void update_last_seen(T id, uint64_t now_ms)
+    {
+        update_last_seen(static_cast<NodeId>(id), now_ms);
+    }
+
+    virtual esp_err_t load_from_storage(uint8_t &wifi_channel) = 0;
+    virtual void persist(uint8_t wifi_channel)                 = 0;
 };
 
 class ITxStateMachine
@@ -50,6 +78,14 @@ public:
     };
     virtual ScanResult scan(uint8_t start_channel) = 0;
     virtual void update_node_info(NodeId id, NodeType type) = 0;
+
+    template <typename T1, typename T2,
+              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    void update_node_info(T1 id, T2 type)
+    {
+        update_node_info(static_cast<NodeId>(id), static_cast<NodeType>(type));
+    }
 };
 
 class IMessageCodec
@@ -113,10 +149,33 @@ class IHeartbeatManager
 public:
     virtual ~IHeartbeatManager() = default;
     virtual esp_err_t init(uint32_t interval_ms, NodeType type) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeType)>>
+    esp_err_t init(uint32_t interval_ms, T type)
+    {
+        return init(interval_ms, static_cast<NodeType>(type));
+    }
+
     virtual void update_node_id(NodeId id) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    void update_node_id(T id)
+    {
+        update_node_id(static_cast<NodeId>(id));
+    }
+
     virtual esp_err_t deinit() = 0;
     virtual void handle_response(NodeId hub_id, uint8_t channel) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    void handle_response(T hub_id, uint8_t channel)
+    {
+        handle_response(static_cast<NodeId>(hub_id), channel);
+    }
+
     virtual void handle_request(NodeId sender_id, const uint8_t *mac, uint64_t uptime_ms) = 0;
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    void handle_request(T sender_id, const uint8_t *mac, uint64_t uptime_ms)
+    {
+        handle_request(static_cast<NodeId>(sender_id), mac, uptime_ms);
+    }
 };
 
 class IPairingManager
@@ -124,6 +183,14 @@ class IPairingManager
 public:
     virtual ~IPairingManager() = default;
     virtual esp_err_t init(NodeType type, NodeId id) = 0;
+    template <typename T1, typename T2,
+              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeType)>,
+              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeId)>>
+    esp_err_t init(T1 type, T2 id)
+    {
+        return init(static_cast<NodeType>(type), static_cast<NodeId>(id));
+    }
+
     virtual esp_err_t deinit() = 0;
     virtual esp_err_t start(uint32_t timeout_ms) = 0;
     virtual bool is_active() const = 0;
@@ -135,8 +202,16 @@ class IMessageRouter
 {
 public:
     virtual ~IMessageRouter() = default;
-    virtual void handle_packet(const RxPacket &packet) = 0;
+    virtual void handle_packet(const RxPacket &packet)       = 0;
     virtual bool should_dispatch_to_worker(MessageType type) = 0;
-    virtual void set_app_queue(QueueHandle_t app_queue) = 0;
-    virtual void set_node_info(NodeId id, NodeType type) = 0;
+    virtual void set_app_queue(QueueHandle_t app_queue)      = 0;
+    virtual void set_node_info(NodeId id, NodeType type)     = 0;
+
+    template <typename T1, typename T2,
+              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    void set_node_info(T1 id, T2 type)
+    {
+        set_node_info(static_cast<NodeId>(id), static_cast<NodeType>(type));
+    }
 };

--- a/include/espnow_manager.hpp
+++ b/include/espnow_manager.hpp
@@ -33,8 +33,8 @@ struct EspNowConfig
 
     // Default constructor
     EspNowConfig()
-        : node_id(NodeId::HUB)
-        , node_type(NodeType::UNKNOWN)
+        : node_id(ReservedIds::HUB)
+        , node_type(ReservedTypes::UNKNOWN)
         , app_rx_queue(nullptr)
         , wifi_channel(DEFAULT_WIFI_CHANNEL)
         , ack_timeout_ms(DEFAULT_ACK_TIMEOUT_MS)
@@ -74,16 +74,63 @@ public:
                         const void *payload,
                         size_t len,
                         bool require_ack = false);
+
+    template <typename T1, typename T2,
+              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(PayloadType)>>
+    esp_err_t send_data(T1 dest_node_id,
+                        T2 payload_type,
+                        const void *payload,
+                        size_t len,
+                        bool require_ack = false)
+    {
+        return send_data(static_cast<NodeId>(dest_node_id),
+                         static_cast<PayloadType>(payload_type),
+                         payload,
+                         len,
+                         require_ack);
+    }
+
     esp_err_t send_command(NodeId dest_node_id,
                            CommandType command_type,
                            const void *payload,
                            size_t len,
                            bool require_ack = false);
+
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    esp_err_t send_command(T dest_node_id,
+                           CommandType command_type,
+                           const void *payload,
+                           size_t len,
+                           bool require_ack = false)
+    {
+        return send_command(static_cast<NodeId>(dest_node_id),
+                            command_type,
+                            payload,
+                            len,
+                            require_ack);
+    }
+
     esp_err_t confirm_reception(AckStatus status);
 
     // Peer Management Functions
     esp_err_t add_peer(NodeId node_id, const uint8_t *mac, uint8_t channel, NodeType type);
+
+    template <typename T1, typename T2,
+              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    esp_err_t add_peer(T1 node_id, const uint8_t *mac, uint8_t channel, T2 type)
+    {
+        return add_peer(static_cast<NodeId>(node_id), mac, channel, static_cast<NodeType>(type));
+    }
+
     esp_err_t remove_peer(NodeId node_id);
+
+    template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
+    esp_err_t remove_peer(T node_id)
+    {
+        return remove_peer(static_cast<NodeId>(node_id));
+    }
     std::vector<PeerInfo> get_peers();
     std::vector<NodeId> get_offline_peers() const;
     esp_err_t start_pairing(uint32_t timeout_ms = 30000);

--- a/include/heartbeat_manager.hpp
+++ b/include/heartbeat_manager.hpp
@@ -10,6 +10,11 @@ public:
     RealHeartbeatManager(ITxManager &tx_mgr, IPeerManager &peer_mgr, IMessageCodec &codec, NodeId my_id);
     ~RealHeartbeatManager();
 
+    using IHeartbeatManager::handle_request;
+    using IHeartbeatManager::handle_response;
+    using IHeartbeatManager::init;
+    using IHeartbeatManager::update_node_id;
+
     esp_err_t init(uint32_t interval_ms, NodeType type) override;
     void update_node_id(NodeId id) override;
     esp_err_t deinit() override;

--- a/include/message_router.hpp
+++ b/include/message_router.hpp
@@ -13,7 +13,13 @@ public:
                       IMessageCodec &message_codec);
 
     void set_app_queue(QueueHandle_t app_queue) override { app_queue_ = app_queue; }
-    void set_node_info(NodeId id, NodeType type) override { my_id_ = id; my_type_ = type; }
+
+    using IMessageRouter::set_node_info;
+    void set_node_info(NodeId id, NodeType type) override
+    {
+        my_id_   = id;
+        my_type_ = type;
+    }
 
     void handle_packet(const RxPacket &packet) override;
     bool should_dispatch_to_worker(MessageType type) override;
@@ -28,6 +34,6 @@ private:
     IMessageCodec &message_codec_;
 
     QueueHandle_t app_queue_ = nullptr;
-    NodeId my_id_ = NodeId::HUB;
-    NodeType my_type_ = NodeType::HUB;
+    NodeId my_id_ = ReservedIds::HUB;
+    NodeType my_type_ = ReservedTypes::HUB;
 };

--- a/include/pairing_manager.hpp
+++ b/include/pairing_manager.hpp
@@ -11,6 +11,8 @@ public:
     RealPairingManager(ITxManager &tx_mgr, IPeerManager &peer_mgr, IMessageCodec &codec);
     ~RealPairingManager();
 
+    using IPairingManager::init;
+
     esp_err_t init(NodeType type, NodeId id) override;
     esp_err_t deinit() override;
     esp_err_t start(uint32_t timeout_ms) override;

--- a/include/peer_manager.hpp
+++ b/include/peer_manager.hpp
@@ -11,6 +11,11 @@ public:
     RealPeerManager(IStorage &storage);
     ~RealPeerManager();
 
+    using IPeerManager::add;
+    using IPeerManager::find_mac;
+    using IPeerManager::remove;
+    using IPeerManager::update_last_seen;
+
     esp_err_t add(NodeId id, const uint8_t *mac, uint8_t channel, NodeType type, uint32_t heartbeat_interval_ms = 0) override;
     esp_err_t remove(NodeId id) override;
     bool find_mac(NodeId id, uint8_t *mac) override;

--- a/include/protocol_messages.hpp
+++ b/include/protocol_messages.hpp
@@ -60,26 +60,6 @@ struct AckMessage
     uint32_t processing_time_us;
 };
 
-struct WaterLevelReport
-{
-    MessageHeader header;
-    uint16_t level_permille;
-    float distance_cm;
-    uint16_t battery_mv;
-    UsQuality quality;
-    UsFailure failure;
-    bool float_switch_is_full;
-    bool backup_mode_active;
-};
-
-struct SolarSensorReport
-{
-    MessageHeader header;
-    uint16_t voltage_mv;
-    uint16_t current_ma;
-    uint16_t power_mw;
-};
-
 struct OtaCommand
 {
     MessageHeader header;
@@ -102,8 +82,4 @@ static_assert(sizeof(HeartbeatMessage) <= MAX_PAYLOAD_SIZE,
 static_assert(sizeof(HeartbeatResponse) <= MAX_PAYLOAD_SIZE,
               "HeartbeatResponse payload is too large");
 static_assert(sizeof(AckMessage) <= MAX_PAYLOAD_SIZE, "AckMessage payload is too large");
-static_assert(sizeof(WaterLevelReport) <= MAX_PAYLOAD_SIZE,
-              "WaterLevelReport payload is too large");
-static_assert(sizeof(SolarSensorReport) <= MAX_PAYLOAD_SIZE,
-              "SolarSensorReport payload is too large");
 static_assert(sizeof(OtaCommand) <= MAX_PAYLOAD_SIZE, "OtaCommand payload is too large");

--- a/message_router.cpp
+++ b/message_router.cpp
@@ -86,7 +86,7 @@ bool RealMessageRouter::should_dispatch_to_worker(MessageType type)
 
 void RealMessageRouter::handle_scan_probe(const RxPacket &packet)
 {
-    if (my_type_ != NodeType::HUB) return;
+    if (my_type_ != ReservedTypes::HUB) return;
     auto header_opt = message_codec_.decode_header(packet.data, packet.len);
     if (!header_opt) return;
 


### PR DESCRIPTION
This refactoring transforms the ESP-NOW component from a project-specific implementation into a generic library. By replacing specific `enum class` definitions for IDs and Types with raw `uint8_t` aliases and providing template-based bridge functions, we allow multiple projects to use the same component with their own node dictionaries.

Key Changes:
1.  **Generic Types:** `NodeId`, `NodeType`, and `PayloadType` are now aliases for `uint8_t`.
2.  **Core Constants:** `ReservedIds::HUB`, `ReservedIds::BROADCAST`, and `ReservedTypes::HUB` provide the necessary constants for core logic without application naming conflicts.
3.  **Type Safety:** Template overloads in public interfaces allow passing application-specific enums directly, maintaining type safety while internally working with generic bytes.
4.  **Decoupling:** All irrigation-specific reports and IDs are isolated in `include/app_protocol_types.hpp`.
5.  **Test Stability:** Host tests now use internal `TestNodeId` enums, making them immune to changes in the real application's node list.

The implementation was verified by building and passing all host tests in `host_test/peer_manager` and `host_test/espnow_facade`.

---
*PR created automatically by Jules for task [12345197534506275995](https://jules.google.com/task/12345197534506275995) started by @aluiziotomazelli*