### PR TITLE
Add Doxygen documentation to EspNowManager

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,97 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+
+# ============================================================================
+# INDENTATION AND SPACING
+# ============================================================================
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+NamespaceIndentation: None
+AccessModifierOffset: -4
+ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 4
+
+# ============================================================================
+# FUNCTION AND ARGUMENT LAYOUT
+# ============================================================================
+ColumnLimit: 120
+# Forces a break after '(' if arguments don't fit on a single line
+AlignAfterOpenBracket: AlwaysBreak
+# Prevents multiple parameters from being packed on the same line after a break
+BinPackParameters: false
+BinPackArguments: false
+# Allows empty functions (like virtual destructors) to stay on one line
+AllowShortFunctionsOnASingleLine: Empty
+
+# ============================================================================
+# POINTERS AND REFERENCES
+# ============================================================================
+# Keeps the pointer to the right: void *payload
+PointerAlignment: Right
+DerivePointerAlignment: false
+
+# ============================================================================
+# ALIGNMENT SETTINGS
+# ============================================================================
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+# ============================================================================
+# LINE BREAKS AND CONTROL
+# ============================================================================
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: true
+
+# ============================================================================
+# BRACE WRAPPING
+# ============================================================================
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: false
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# ============================================================================
+# INCLUDE SORTING
+# ============================================================================
+SortIncludes: true
+IncludeCategories:
+  - Regex: '^<openthread/.*/'
+    Priority: 4
+  - Regex: '^<openthread/'
+    Priority: 3
+  - Regex: '^<'
+    Priority: 2
+  - Regex: '^".*/'
+    Priority: 5
+  - Regex: '^"'
+    Priority: 1
+
+# ============================================================================
+# MISCELLANEOUS
+# ============================================================================
+Standard: Cpp11
+ReflowComments:

--- a/espnow_manager
+++ b/espnow_manager
@@ -1,0 +1,1 @@
+/home/german/dev/workspaces/idf-components/espnow_manager

--- a/espnow_manager
+++ b/espnow_manager
@@ -1,1 +1,0 @@
-/home/german/dev/workspaces/idf-components/espnow_manager

--- a/host_test/README.md
+++ b/host_test/README.md
@@ -1,12 +1,87 @@
 # Host Tests
 
-This directory contains Linux-based unit tests for the EspNow component.
-Tests are organized by class/responsibility.
+This directory contains Linux-based host tests for the EspNow component, providing a robust testing environment that doesn't require physical hardware.
 
-## Structure
-- `espnow_facade/`: Tests for the main `EspNow` class using dependency injection and mocks.
-- `peer_manager/`: (Planned) Tests for the `PeerManager` class.
-- `tx_state_machine/`: (Planned) Tests for the `TxStateMachine` class.
+## Test Scope
+The tests cover individual components (Unit Tests) and their interactions (Integration Tests). We aim for high coverage across all critical communication logic, including:
+- Protocol encoding/decoding and CRC validation.
+- Peer management and persistent storage.
+- Transmission state machine and retry logic.
+- Heartbeat monitoring and node health tracking.
+- Pairing process and channel discovery.
+- Message routing and dispatching.
 
-## How to run
-(Specific instructions depend on the environment setup, typically using `idf.py build` or `cmake` for host target)
+## Mocks and Abstractions
+
+To isolate the logic under test, we use several mocking strategies:
+
+### 1. ESP-IDF Mocks
+We leverage the ESP-IDF host testing framework to mock standard components like `esp_wifi` and `esp_now`. These mocks simulate the behavior of the ESP32 hardware and drivers.
+
+### 2. CMock Generated Mocks
+Mocks generated automatically by CMock from C headers. These are primarily used for low-level IDF APIs, allowing us to expect specific function calls and return predetermined values.
+
+### 3. Custom Mocks (`/mocks`)
+Located in the root `mocks/` directory, these are hand-written C++ mocks for our own internal interfaces (e.g., `IPeerManager`, `ITxManager`). They provide:
+- **Call Spying:** Track if methods were called and with what arguments.
+- **Stubbing:** Configure complex return values or behaviors for specific test scenarios.
+- **State Simulation:** Simulate internal state changes (like task handles or queue statuses).
+
+## Directory Structure
+- `peer_manager/`: Tests for the `RealPeerManager` class.
+- `tx_state_machine/`: Tests for the `RealTxStateMachine` class.
+- `channel_scanner/`: Tests for the `RealChannelScanner` class.
+- `espnow_storage/`: Tests for the `EspNowStorage` and its backends.
+- `heartbeat_manager/`: Tests for the `RealHeartbeatManager`.
+- `message_codec/`: Tests for the `RealMessageCodec`.
+- `message_router/`: Tests for the `RealMessageRouter`.
+- `pairing_manager/`: Tests for the `RealPairingManager`.
+- `tx_manager/`: Tests for the `RealTxManager`.
+- `wifi_hal/`: Tests for the `RealWiFiHAL`.
+- `espnow_manager_main/`: Integration tests for the full `EspNowManager` assembly.
+- `espnow_manager_singleton/`: Specific tests for singleton lifecycle and static callbacks.
+- `utils/`: Common test utilities and helpers.
+
+## Running Tests
+
+### Manual Execution
+To run a specific test suite manually:
+1. Navigate to the test directory:
+   ```bash
+   cd host_test/espnow_storage
+   ```
+2. Set the target to linux:
+   ```bash
+   idf.py --preview set-target linux
+   ```
+3. Build and run:
+   ```bash
+   idf.py build
+   ./build/espnow_storage_host_test.elf
+   ```
+
+### Automated Execution
+We use `pytest` to discover and run all host tests automatically.
+- Run all tests:
+  ```bash
+  pytest
+  ```
+- Run with full logs:
+  ```bash
+  pytest -s
+  ```
+- Run a clean build from scratch (cleans all build folders):
+  ```bash
+  CLEAN_BUILD=1 python3 -m pytest -s test_host_automation.py
+  ```
+
+## Coverage Reports
+You can generate a unified coverage report for all host tests.
+1. Run the tests first to generate execution data.
+2. Run the coverage script:
+   ```bash
+   python3 generate_coverage.py
+   ```
+The results will be available in:
+- HTML Report: `host_test/coverage/html/index.html`
+- Text Summary: `host_test/coverage/summary.txt`

--- a/host_test/generate_coverage.py
+++ b/host_test/generate_coverage.py
@@ -1,0 +1,148 @@
+# generate_coverage.py
+import os
+import subprocess
+import glob
+import sys
+import shutil
+
+# Define paths
+HOST_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+COVERAGE_DIR = os.path.join(HOST_TEST_DIR, "coverage")
+HTML_REPORT_DIR = os.path.join(COVERAGE_DIR, "html")
+UNIFIED_INFO = os.path.join(COVERAGE_DIR, "unified_coverage.info")
+IGNORE_DIRS = ["espnow_facade", "build", "__pycache__", ".pytest_cache", "coverage"]
+
+def get_coverage_ignore_patterns():
+    ignore_file = os.path.join(HOST_TEST_DIR, "coverage_ignore.txt")
+    patterns = []
+    if os.path.exists(ignore_file):
+        with open(ignore_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+    return patterns
+
+def get_test_directories():
+    dirs = []
+    for entry in os.listdir(HOST_TEST_DIR):
+        full_path = os.path.join(HOST_TEST_DIR, entry)
+        if os.path.isdir(full_path) and entry not in IGNORE_DIRS:
+            if os.path.exists(os.path.join(full_path, "CMakeLists.txt")):
+                dirs.append(entry)
+    return sorted(dirs)
+
+# Absolute paths are maintained for better local HTML report integration
+def print_simple_summary(info_file, label, summary_file=None):
+    """Print a clean summary from lcov --summary output and optionally write to file."""
+    try:
+        # Added --ignore-errors gcov to be more permissive
+        output = subprocess.check_output(["lcov", "--summary", info_file, "--ignore-errors", "gcov"], stderr=subprocess.STDOUT, text=True)
+        header = f"{label}:"
+        print(header)
+        if summary_file:
+            summary_file.write(header + "\n")
+
+        for line in output.splitlines():
+            # Match lines that look like: "  lines......: 88.2% (15 of 17 lines)"
+            # or "  functions..: 83.3% (5 of 6 functions)"
+            if ":" in line and ("lines" in line or "functions" in line):
+                clean_line = line.strip()
+                print(f"  {clean_line}")
+                if summary_file:
+                    summary_file.write(f"  {clean_line}\n")
+
+        if summary_file:
+            summary_file.write("\n")
+    except Exception:
+        msg = f"  Summary not available for {label}"
+        print(msg)
+        if summary_file:
+            summary_file.write(msg + "\n\n")
+
+def main():
+    if not os.path.exists(COVERAGE_DIR):
+        os.makedirs(COVERAGE_DIR)
+
+    if os.path.exists(UNIFIED_INFO):
+        os.remove(UNIFIED_INFO)
+
+    summary_path = os.path.join(COVERAGE_DIR, "summary.txt")
+
+    collected_info_files = []
+    ignore_patterns = get_coverage_ignore_patterns()
+
+    print("========== Generating Coverage Reports ==========\n")
+
+    with open(summary_path, "w") as summary_file:
+        summary_file.write("========== Host Test Coverage Summary ==========\n\n")
+
+        for test_dir in get_test_directories():
+            work_dir = os.path.join(HOST_TEST_DIR, test_dir)
+            build_dir = os.path.join(work_dir, "build")
+
+            if not os.path.exists(build_dir):
+                continue
+
+            coverage_info = os.path.join(build_dir, "coverage.info")
+            coverage_filtered = os.path.join(build_dir, "coverage_filtered.info")
+
+            # Capture coverage
+            cmd_capture = ["lcov", "--capture", "--directory", build_dir, "--output-file", coverage_info, "--quiet"]
+            try:
+                subprocess.check_call(cmd_capture, cwd=work_dir)
+            except subprocess.CalledProcessError:
+                cmd_capture_fallback = ["lcov", "--capture", "--directory", build_dir, "--output-file", coverage_info, "--ignore-errors", "gcov", "--quiet"]
+                try:
+                    subprocess.check_call(cmd_capture_fallback, cwd=work_dir)
+                except subprocess.CalledProcessError:
+                     continue
+
+            # Filter coverage
+            source_info = coverage_info
+            if ignore_patterns:
+                cmd_remove = ["lcov", "--remove", coverage_info] + ignore_patterns + ["--output-file", coverage_filtered, "--quiet"]
+                try:
+                    subprocess.check_call(cmd_remove, cwd=work_dir)
+                    source_info = coverage_filtered
+                except subprocess.CalledProcessError:
+                    pass
+
+            # Collected for merging
+            collected_info_files.append(source_info)
+
+            # Print simple summary and log to file
+            print_simple_summary(source_info, test_dir, summary_file)
+
+        if not collected_info_files:
+            print("No coverage data found. Please run tests first.")
+            sys.exit(1)
+
+        # Merge all coverage data
+        print("\nMerging coverage data...")
+        cmd_merge = ["lcov"]
+        for f in collected_info_files:
+            cmd_merge.extend(["-a", f])
+        cmd_merge.extend(["-o", UNIFIED_INFO, "--quiet"])
+
+        try:
+            subprocess.check_call(cmd_merge, cwd=HOST_TEST_DIR)
+        except subprocess.CalledProcessError:
+            print("Failed to merge coverage data.")
+            sys.exit(1)
+
+        print("")
+        print_simple_summary(UNIFIED_INFO, "UNIFIED REPORT", summary_file)
+
+    print(f"\nGenerating HTML report in {HTML_REPORT_DIR}...")
+    cmd_genhtml = ["genhtml", UNIFIED_INFO, "--output-directory", HTML_REPORT_DIR, "--quiet", "--title", "Host Test Coverage"]
+    try:
+        subprocess.check_call(cmd_genhtml, cwd=HOST_TEST_DIR)
+        print(f"\nSuccess! Full report available at: file://{HTML_REPORT_DIR}/index.html")
+        print(f"Text summary available at: {summary_path}")
+    except subprocess.CalledProcessError:
+        print("Failed to generate HTML report. Tracefile might contain invalid paths.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/include/app_protocol_types.hpp
+++ b/include/app_protocol_types.hpp
@@ -76,6 +76,6 @@ struct SolarSensorReport
 
 #pragma pack(pop)
 
-// Validações de tamanho para garantir que nenhum payload exceda o limite do ESP-NOW
+// Validations to ensure that no payload exceeds the ESP-NOW limit
 static_assert(sizeof(WaterLevelReport) <= MAX_PAYLOAD_SIZE, "WaterLevelReport payload is too large");
 static_assert(sizeof(SolarSensorReport) <= MAX_PAYLOAD_SIZE, "SolarSensorReport payload is too large");

--- a/include/espnow_interfaces.hpp
+++ b/include/espnow_interfaces.hpp
@@ -29,20 +29,18 @@ public:
      * @brief Add peer to list
      * @internal
      */
-    virtual esp_err_t add(NodeId id,
-                          const uint8_t *mac,
-                          uint8_t channel,
-                          NodeType type,
-                          uint32_t heartbeat_interval_ms = 0) = 0;
+    virtual esp_err_t
+    add(NodeId id, const uint8_t *mac, uint8_t channel, NodeType type, uint32_t heartbeat_interval_ms = 0) = 0;
 
     /**
      * @brief Template for adding peer using enums
      * @internal
      */
-    template <typename T1,
-              typename T2,
-              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
-              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    template <
+        typename T1,
+        typename T2,
+        typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+        typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
     esp_err_t add(T1 id, const uint8_t *mac, uint8_t channel, T2 type, uint32_t heartbeat_interval_ms = 0)
     {
         return add(static_cast<NodeId>(id), mac, channel, static_cast<NodeType>(type), heartbeat_interval_ms);
@@ -123,7 +121,8 @@ public:
 
 /**
  * @interface ITxStateMachine
- * @brief State machine for managing transmission lifecycle and retries (internal)
+ * @brief State machine for managing transmission lifecycle and retries
+ * (internal)
  * @internal
  */
 class ITxStateMachine
@@ -176,10 +175,11 @@ public:
     virtual void update_node_info(NodeId id, NodeType type) = 0;
 
     /** @internal */
-    template <typename T1,
-              typename T2,
-              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
-              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    template <
+        typename T1,
+        typename T2,
+        typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+        typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
     void update_node_info(T1 id, T2 type)
     {
         update_node_info(static_cast<NodeId>(id), static_cast<NodeType>(type));
@@ -235,9 +235,8 @@ public:
     /** @internal */
     virtual esp_err_t load(uint8_t &wifi_channel, std::vector<PersistentPeer> &peers) = 0;
     /** @internal */
-    virtual esp_err_t save(uint8_t wifi_channel,
-                           const std::vector<PersistentPeer> &peers,
-                           bool force_nvs_commit = true) = 0;
+    virtual esp_err_t
+    save(uint8_t wifi_channel, const std::vector<PersistentPeer> &peers, bool force_nvs_commit = true) = 0;
 };
 
 /**
@@ -352,10 +351,11 @@ public:
     /** @internal */
     virtual esp_err_t init(NodeType type, NodeId id) = 0;
     /** @internal */
-    template <typename T1,
-              typename T2,
-              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeType)>,
-              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeId)>>
+    template <
+        typename T1,
+        typename T2,
+        typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeType)>,
+        typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeId)>>
     esp_err_t init(T1 type, T2 id)
     {
         return init(static_cast<NodeType>(type), static_cast<NodeId>(id));
@@ -375,7 +375,8 @@ public:
 
 /**
  * @interface IMessageRouter
- * @brief Routing of received packets to appropriate managers or app queue (internal)
+ * @brief Routing of received packets to appropriate managers or app queue
+ * (internal)
  * @internal
  */
 class IMessageRouter
@@ -393,10 +394,11 @@ public:
     virtual void set_node_info(NodeId id, NodeType type) = 0;
 
     /** @internal */
-    template <typename T1,
-              typename T2,
-              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
-              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    template <
+        typename T1,
+        typename T2,
+        typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+        typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
     void set_node_info(T1 id, T2 type)
     {
         set_node_info(static_cast<NodeId>(id), static_cast<NodeType>(type));

--- a/include/espnow_interfaces.hpp
+++ b/include/espnow_interfaces.hpp
@@ -13,16 +13,32 @@
 #include "espnow_types.hpp"
 #include "protocol_messages.hpp"
 
+/**
+ * @interface IPeerManager
+ * @brief Peer list management (internal)
+ *
+ * @note This is an internal interface.
+ *       Users should use IEspNowManager::add_peer() instead.
+ */
 class IPeerManager
 {
 public:
-    virtual ~IPeerManager()                                   = default;
+    virtual ~IPeerManager() = default;
+
+    /**
+     * @brief Add peer to list
+     * @internal
+     */
     virtual esp_err_t add(NodeId id,
                           const uint8_t *mac,
                           uint8_t channel,
                           NodeType type,
                           uint32_t heartbeat_interval_ms = 0) = 0;
 
+    /**
+     * @brief Template for adding peer using enums
+     * @internal
+     */
     template <typename T1,
               typename T2,
               typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
@@ -32,62 +48,134 @@ public:
         return add(static_cast<NodeId>(id), mac, channel, static_cast<NodeType>(type), heartbeat_interval_ms);
     }
 
+    /**
+     * @brief Remove peer from list
+     * @internal
+     */
     virtual esp_err_t remove(NodeId id) = 0;
+
+    /**
+     * @brief Template for removing peer
+     * @internal
+     */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     esp_err_t remove(T id)
     {
         return remove(static_cast<NodeId>(id));
     }
 
+    /**
+     * @brief Find MAC address for a given Node ID
+     * @internal
+     */
     virtual bool find_mac(NodeId id, uint8_t *mac) = 0;
+
+    /**
+     * @brief Template for finding MAC
+     * @internal
+     */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     bool find_mac(T id, uint8_t *mac)
     {
         return find_mac(static_cast<NodeId>(id), mac);
     }
 
-    virtual std::vector<PeerInfo> get_all()                  = 0;
+    /**
+     * @brief Get all registered peers
+     * @internal
+     */
+    virtual std::vector<PeerInfo> get_all() = 0;
+
+    /**
+     * @brief Get peers that haven't been seen since a timeout
+     * @internal
+     */
     virtual std::vector<NodeId> get_offline(uint64_t now_ms) = 0;
 
+    /**
+     * @brief Update the last seen timestamp for a peer
+     * @internal
+     */
     virtual void update_last_seen(NodeId id, uint64_t now_ms) = 0;
+
+    /**
+     * @brief Template for updating last seen
+     * @internal
+     */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     void update_last_seen(T id, uint64_t now_ms)
     {
         update_last_seen(static_cast<NodeId>(id), now_ms);
     }
 
+    /**
+     * @brief Load peer list from persistent storage
+     * @internal
+     */
     virtual esp_err_t load_from_storage(uint8_t &wifi_channel) = 0;
-    virtual void persist(uint8_t wifi_channel)                 = 0;
+
+    /**
+     * @brief Persist peer list to storage
+     * @internal
+     */
+    virtual void persist(uint8_t wifi_channel) = 0;
 };
 
+/**
+ * @interface ITxStateMachine
+ * @brief State machine for managing transmission lifecycle and retries (internal)
+ * @internal
+ */
 class ITxStateMachine
 {
 public:
-    virtual ~ITxStateMachine()                                  = default;
-    virtual TxState on_tx_success(bool requires_ack)            = 0;
-    virtual TxState on_ack_received()                           = 0;
-    virtual TxState on_ack_timeout()                            = 0;
-    virtual TxState on_physical_fail()                          = 0;
-    virtual TxState on_max_retries()                            = 0;
-    virtual void on_link_alive()                                = 0;
-    virtual TxState get_state() const                           = 0;
-    virtual void reset()                                        = 0;
+    virtual ~ITxStateMachine() = default;
+
+    /** @internal */
+    virtual TxState on_tx_success(bool requires_ack) = 0;
+    /** @internal */
+    virtual TxState on_ack_received() = 0;
+    /** @internal */
+    virtual TxState on_ack_timeout() = 0;
+    /** @internal */
+    virtual TxState on_physical_fail() = 0;
+    /** @internal */
+    virtual TxState on_max_retries() = 0;
+    /** @internal */
+    virtual void on_link_alive() = 0;
+    /** @internal */
+    virtual TxState get_state() const = 0;
+    /** @internal */
+    virtual void reset() = 0;
+    /** @internal */
     virtual void set_pending_ack(const PendingAck &pending_ack) = 0;
-    virtual std::optional<PendingAck> get_pending_ack() const   = 0;
+    /** @internal */
+    virtual std::optional<PendingAck> get_pending_ack() const = 0;
 };
 
+/**
+ * @interface IChannelScanner
+ * @brief WiFi channel scanning to find HUB or optimal channel (internal)
+ * @internal
+ */
 class IChannelScanner
 {
 public:
     virtual ~IChannelScanner() = default;
+
+    /** @internal */
     struct ScanResult
     {
         uint8_t channel;
         bool hub_found;
     };
-    virtual ScanResult scan(uint8_t start_channel)          = 0;
+
+    /** @internal */
+    virtual ScanResult scan(uint8_t start_channel) = 0;
+    /** @internal */
     virtual void update_node_info(NodeId id, NodeType type) = 0;
 
+    /** @internal */
     template <typename T1,
               typename T2,
               typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
@@ -98,86 +186,152 @@ public:
     }
 };
 
+/**
+ * @interface IMessageCodec
+ * @brief Message encoding/decoding and CRC validation (internal)
+ * @internal
+ */
 class IMessageCodec
 {
 public:
-    virtual ~IMessageCodec()                                                                          = default;
+    virtual ~IMessageCodec() = default;
+
+    /** @internal */
     virtual std::vector<uint8_t> encode(const MessageHeader &header, const void *payload, size_t len) = 0;
-    virtual std::optional<MessageHeader> decode_header(const uint8_t *data, size_t len)               = 0;
-    virtual bool validate_crc(const uint8_t *data, size_t len)                                        = 0;
-    virtual uint8_t calculate_crc(const uint8_t *data, size_t len)                                    = 0;
+    /** @internal */
+    virtual std::optional<MessageHeader> decode_header(const uint8_t *data, size_t len) = 0;
+    /** @internal */
+    virtual bool validate_crc(const uint8_t *data, size_t len) = 0;
+    /** @internal */
+    virtual uint8_t calculate_crc(const uint8_t *data, size_t len) = 0;
 };
 
+/**
+ * @interface IPersistenceBackend
+ * @brief Low-level storage backend (NVS/RTC) (internal)
+ * @internal
+ */
 class IPersistenceBackend
 {
 public:
-    virtual ~IPersistenceBackend()                        = default;
-    virtual esp_err_t load(void *data, size_t size)       = 0;
+    virtual ~IPersistenceBackend() = default;
+
+    /** @internal */
+    virtual esp_err_t load(void *data, size_t size) = 0;
+    /** @internal */
     virtual esp_err_t save(const void *data, size_t size) = 0;
 };
 
+/**
+ * @interface IStorage
+ * @brief Higher-level storage management for peers and config (internal)
+ * @internal
+ */
 class IStorage
 {
 public:
-    virtual ~IStorage()                                                               = default;
+    virtual ~IStorage() = default;
+
+    /** @internal */
     virtual esp_err_t load(uint8_t &wifi_channel, std::vector<PersistentPeer> &peers) = 0;
+    /** @internal */
     virtual esp_err_t save(uint8_t wifi_channel,
                            const std::vector<PersistentPeer> &peers,
-                           bool force_nvs_commit = true)                              = 0;
+                           bool force_nvs_commit = true) = 0;
 };
 
+/**
+ * @interface IWiFiHAL
+ * @brief Hardware Abstraction Layer for WiFi and ESP-NOW drivers (internal)
+ * @internal
+ */
 class IWiFiHAL
 {
 public:
-    virtual ~IWiFiHAL()                                                                = default;
-    virtual esp_err_t set_channel(uint8_t channel)                                     = 0;
-    virtual esp_err_t get_channel(uint8_t *channel)                                    = 0;
+    virtual ~IWiFiHAL() = default;
+
+    /** @internal */
+    virtual esp_err_t set_channel(uint8_t channel) = 0;
+    /** @internal */
+    virtual esp_err_t get_channel(uint8_t *channel) = 0;
+    /** @internal */
     virtual esp_err_t send_packet(const uint8_t *mac, const uint8_t *data, size_t len) = 0;
-    virtual bool wait_for_event(uint32_t event_mask, uint32_t timeout_ms)              = 0;
-    virtual void set_task_to_notify(TaskHandle_t task_handle)                          = 0;
+    /** @internal */
+    virtual bool wait_for_event(uint32_t event_mask, uint32_t timeout_ms) = 0;
+    /** @internal */
+    virtual void set_task_to_notify(TaskHandle_t task_handle) = 0;
 };
 
+/**
+ * @interface ITxManager
+ * @brief Manager for transmission queue and background sending task (internal)
+ * @internal
+ */
 class ITxManager
 {
 public:
-    virtual ~ITxManager()                                             = default;
+    virtual ~ITxManager() = default;
+
+    /** @internal */
     virtual esp_err_t init(uint32_t stack_size, UBaseType_t priority) = 0;
-    virtual esp_err_t deinit()                                        = 0;
-    virtual esp_err_t queue_packet(const TxPacket &packet)            = 0;
-    virtual void notify_physical_fail()                               = 0;
-    virtual void notify_link_alive()                                  = 0;
-    virtual void notify_logical_ack()                                 = 0;
-    virtual void notify_hub_found()                                   = 0;
-    virtual TaskHandle_t get_task_handle() const                      = 0;
+    /** @internal */
+    virtual esp_err_t deinit() = 0;
+    /** @internal */
+    virtual esp_err_t queue_packet(const TxPacket &packet) = 0;
+    /** @internal */
+    virtual void notify_physical_fail() = 0;
+    /** @internal */
+    virtual void notify_link_alive() = 0;
+    /** @internal */
+    virtual void notify_logical_ack() = 0;
+    /** @internal */
+    virtual void notify_hub_found() = 0;
+    /** @internal */
+    virtual TaskHandle_t get_task_handle() const = 0;
 };
 
+/**
+ * @interface IHeartbeatManager
+ * @brief Heartbeat generation and monitoring (internal)
+ * @internal
+ */
 class IHeartbeatManager
 {
 public:
-    virtual ~IHeartbeatManager()                                = default;
+    virtual ~IHeartbeatManager() = default;
+
+    /** @internal */
     virtual esp_err_t init(uint32_t interval_ms, NodeType type) = 0;
+    /** @internal */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeType)>>
     esp_err_t init(uint32_t interval_ms, T type)
     {
         return init(interval_ms, static_cast<NodeType>(type));
     }
 
+    /** @internal */
     virtual void update_node_id(NodeId id) = 0;
+    /** @internal */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     void update_node_id(T id)
     {
         update_node_id(static_cast<NodeId>(id));
     }
 
-    virtual esp_err_t deinit()                                   = 0;
+    /** @internal */
+    virtual esp_err_t deinit() = 0;
+    /** @internal */
     virtual void handle_response(NodeId hub_id, uint8_t channel) = 0;
+    /** @internal */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     void handle_response(T hub_id, uint8_t channel)
     {
         handle_response(static_cast<NodeId>(hub_id), channel);
     }
 
+    /** @internal */
     virtual void handle_request(NodeId sender_id, const uint8_t *mac, uint64_t uptime_ms) = 0;
+    /** @internal */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     void handle_request(T sender_id, const uint8_t *mac, uint64_t uptime_ms)
     {
@@ -185,11 +339,19 @@ public:
     }
 };
 
+/**
+ * @interface IPairingManager
+ * @brief Pairing logic for connecting nodes to HUB (internal)
+ * @internal
+ */
 class IPairingManager
 {
 public:
-    virtual ~IPairingManager()                       = default;
+    virtual ~IPairingManager() = default;
+
+    /** @internal */
     virtual esp_err_t init(NodeType type, NodeId id) = 0;
+    /** @internal */
     template <typename T1,
               typename T2,
               typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeType)>,
@@ -199,22 +361,38 @@ public:
         return init(static_cast<NodeType>(type), static_cast<NodeId>(id));
     }
 
-    virtual esp_err_t deinit()                           = 0;
-    virtual esp_err_t start(uint32_t timeout_ms)         = 0;
-    virtual bool is_active() const                       = 0;
-    virtual void handle_request(const RxPacket &packet)  = 0;
+    /** @internal */
+    virtual esp_err_t deinit() = 0;
+    /** @internal */
+    virtual esp_err_t start(uint32_t timeout_ms) = 0;
+    /** @internal */
+    virtual bool is_active() const = 0;
+    /** @internal */
+    virtual void handle_request(const RxPacket &packet) = 0;
+    /** @internal */
     virtual void handle_response(const RxPacket &packet) = 0;
 };
 
+/**
+ * @interface IMessageRouter
+ * @brief Routing of received packets to appropriate managers or app queue (internal)
+ * @internal
+ */
 class IMessageRouter
 {
 public:
-    virtual ~IMessageRouter()                                = default;
-    virtual void handle_packet(const RxPacket &packet)       = 0;
-    virtual bool should_dispatch_to_worker(MessageType type) = 0;
-    virtual void set_app_queue(QueueHandle_t app_queue)      = 0;
-    virtual void set_node_info(NodeId id, NodeType type)     = 0;
+    virtual ~IMessageRouter() = default;
 
+    /** @internal */
+    virtual void handle_packet(const RxPacket &packet) = 0;
+    /** @internal */
+    virtual bool should_dispatch_to_worker(MessageType type) = 0;
+    /** @internal */
+    virtual void set_app_queue(QueueHandle_t app_queue) = 0;
+    /** @internal */
+    virtual void set_node_info(NodeId id, NodeType type) = 0;
+
+    /** @internal */
     template <typename T1,
               typename T2,
               typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,

--- a/include/espnow_manager.hpp
+++ b/include/espnow_manager.hpp
@@ -11,14 +11,26 @@
 #include "espnow_manager_interface.hpp"
 #include "espnow_storage.hpp"
 
-// Main class for ESP-NOW communication.
+// ========================================
+// ESP-NOW Manager Implementation
+// ========================================
+
+/**
+ * @class EspNowManager
+ * @brief Implementation of IEspNowManager for ESP32 using ESP-NOW.
+ *
+ * @see IEspNowManager for full API documentation.
+ */
 class EspNowManager : public IEspNowManager
 {
 public:
-    // Singleton
+    /** @brief Get the singleton instance of EspNowManager */
     static EspNowManager &instance();
 
-    // Dependency injection constructor for testing
+    /**
+     * @brief Dependency injection constructor for testing
+     * @internal
+     */
     EspNowManager(std::unique_ptr<IPeerManager> peer_manager,
                   std::unique_ptr<ITxManager> tx_manager,
                   IChannelScanner *scanner_ptr,
@@ -31,11 +43,22 @@ public:
     EspNowManager &operator=(const EspNowManager &) = delete;
     virtual ~EspNowManager();
 
-    // Public API
+    // ========================================
+    // Lifecycle
+    // ========================================
+
+    /** @copydoc IEspNowManager::init */
     esp_err_t init(const EspNowConfig &config) override;
+
+    /** @copydoc IEspNowManager::deinit */
     esp_err_t deinit() override;
 
+    // ========================================
+    // Data Communication
+    // ========================================
+
     using IEspNowManager::send_data;
+    /** @copydoc IEspNowManager::send_data */
     esp_err_t send_data(NodeId dest_node_id,
                         PayloadType payload_type,
                         const void *payload,
@@ -43,25 +66,46 @@ public:
                         bool require_ack = false) override;
 
     using IEspNowManager::send_command;
+    /** @copydoc IEspNowManager::send_command */
     esp_err_t send_command(NodeId dest_node_id,
                            CommandType command_type,
                            const void *payload,
                            size_t len,
                            bool require_ack = false) override;
 
+    /** @copydoc IEspNowManager::confirm_reception */
     esp_err_t confirm_reception(AckStatus status) override;
 
-    // Peer Management Functions
+    // ========================================
+    // Peer Management
+    // ========================================
+
     using IEspNowManager::add_peer;
+    /** @copydoc IEspNowManager::add_peer */
     esp_err_t add_peer(NodeId node_id, const uint8_t *mac, uint8_t channel, NodeType type) override;
 
     using IEspNowManager::remove_peer;
+    /** @copydoc IEspNowManager::remove_peer */
     esp_err_t remove_peer(NodeId node_id) override;
 
+    /** @copydoc IEspNowManager::get_peers */
     std::vector<PeerInfo> get_peers() override;
+
+    /** @copydoc IEspNowManager::get_offline_peers */
     std::vector<NodeId> get_offline_peers() const override;
+
+    // ========================================
+    // Pairing
+    // ========================================
+
+    /** @copydoc IEspNowManager::start_pairing */
     esp_err_t start_pairing(uint32_t timeout_ms = 30000) override;
 
+    // ========================================
+    // Status
+    // ========================================
+
+    /** @copydoc IEspNowManager::is_initialized */
     bool is_initialized() const override
     {
         return is_initialized_;

--- a/include/espnow_manager.hpp
+++ b/include/espnow_manager.hpp
@@ -31,13 +31,14 @@ public:
      * @brief Dependency injection constructor for testing
      * @internal
      */
-    EspNowManager(std::unique_ptr<IPeerManager> peer_manager,
-                  std::unique_ptr<ITxManager> tx_manager,
-                  IChannelScanner *scanner_ptr,
-                  std::unique_ptr<IMessageCodec> message_codec,
-                  std::unique_ptr<IHeartbeatManager> heartbeat_manager,
-                  std::unique_ptr<IPairingManager> pairing_manager,
-                  std::unique_ptr<IMessageRouter> message_router);
+    EspNowManager(
+        std::unique_ptr<IPeerManager> peer_manager,
+        std::unique_ptr<ITxManager> tx_manager,
+        IChannelScanner *scanner_ptr,
+        std::unique_ptr<IMessageCodec> message_codec,
+        std::unique_ptr<IHeartbeatManager> heartbeat_manager,
+        std::unique_ptr<IPairingManager> pairing_manager,
+        std::unique_ptr<IMessageRouter> message_router);
 
     EspNowManager(const EspNowManager &)            = delete;
     EspNowManager &operator=(const EspNowManager &) = delete;
@@ -59,19 +60,18 @@ public:
 
     using IEspNowManager::send_data;
     /** @copydoc IEspNowManager::send_data */
-    esp_err_t send_data(NodeId dest_node_id,
-                        PayloadType payload_type,
-                        const void *payload,
-                        size_t len,
-                        bool require_ack = false) override;
+    esp_err_t
+    send_data(NodeId dest_node_id, PayloadType payload_type, const void *payload, size_t len, bool require_ack = false)
+        override;
 
     using IEspNowManager::send_command;
     /** @copydoc IEspNowManager::send_command */
-    esp_err_t send_command(NodeId dest_node_id,
-                           CommandType command_type,
-                           const void *payload,
-                           size_t len,
-                           bool require_ack = false) override;
+    esp_err_t send_command(
+        NodeId dest_node_id,
+        CommandType command_type,
+        const void *payload,
+        size_t len,
+        bool require_ack = false) override;
 
     /** @copydoc IEspNowManager::confirm_reception */
     esp_err_t confirm_reception(AckStatus status) override;

--- a/include/espnow_manager_interface.hpp
+++ b/include/espnow_manager_interface.hpp
@@ -7,20 +7,90 @@
 
 #include "espnow_types.hpp"
 
+// ========================================
+// ESP-NOW Manager Interface
+// ========================================
+
+/**
+ * @interface IEspNowManager
+ * @brief Interface for the ESP-NOW Manager, providing high-level APIs for communication, peer management, and lifecycle.
+ *
+ * This interface defines the contract for managing ESP-NOW communications in a structured way,
+ * supporting both HUB (central controller) and NODE (peripheral) roles.
+ *
+ * @author Jules
+ * @version 1.0.0
+ * @date 2025
+ * @see EspNow for implementation details
+ * @see espnow_types.hpp for data structures
+ */
 class IEspNowManager
 {
 public:
     virtual ~IEspNowManager() = default;
 
-    virtual esp_err_t init(const EspNowConfig &config) = 0;
-    virtual esp_err_t deinit()                         = 0;
+    // ========================================
+    // Lifecycle
+    // ========================================
 
+    /**
+     * @brief Initialize the ESP-NOW Manager
+     *
+     * Sets up the necessary resources, including WiFi, ESP-NOW drivers, tasks, and queues.
+     * For HUB: Prepares to receive data from multiple nodes and manage the peer list.
+     * For NODE: Prepares to communicate with the HUB and optionally starts heartbeats.
+     *
+     * @param config Configuration structure containing node ID, type, and resource settings.
+     * @return ESP_OK on success, or an error code from the underlying ESP-IDF drivers.
+     * @note This method must be called before any other operation.
+     */
+    virtual esp_err_t init(const EspNowConfig &config) = 0;
+
+    /**
+     * @brief Deinitialize the ESP-NOW Manager
+     *
+     * Stops all background tasks, releases memory, and deinitializes the ESP-NOW driver.
+     *
+     * @return ESP_OK on success, or an error code if deinitialization fails.
+     */
+    virtual esp_err_t deinit() = 0;
+
+    // ========================================
+    // Data Communication
+    // ========================================
+
+    /**
+     * @brief Send data to a destination node
+     *
+     * Encapsulates the payload into a standard message format and queues it for transmission.
+     * For HUB: Used to send application data to a specific registered node.
+     * For NODE: Typically used to send sensor data or status updates to the HUB.
+     *
+     * @param dest_node_id ID of the destination node.
+     * @param payload_type Type identifier for the payload (application-defined).
+     * @param payload Pointer to the data buffer to be sent.
+     * @param len Length of the payload in bytes.
+     * @param require_ack If true, the transmission will wait for a logical acknowledgment.
+     * @return ESP_OK if the packet was successfully queued, ESP_ERR_NOT_FOUND if the peer is not registered.
+     */
     virtual esp_err_t send_data(NodeId dest_node_id,
                                 PayloadType payload_type,
                                 const void *payload,
                                 size_t len,
                                 bool require_ack = false) = 0;
 
+    /**
+     * @brief Template overload for send_data using enum types
+     *
+     * @tparam T1 Enum type for NodeId.
+     * @tparam T2 Enum type for PayloadType.
+     * @param dest_node_id Destination node ID.
+     * @param payload_type Payload type.
+     * @param payload Pointer to the data.
+     * @param len Data length.
+     * @param require_ack Logical ACK request.
+     * @return esp_err_t result.
+     */
     template <typename T1,
               typename T2,
               typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
@@ -31,12 +101,37 @@ public:
                          require_ack);
     }
 
+    /**
+     * @brief Send a command to a destination node
+     *
+     * Similar to send_data, but specifically for control commands.
+     * For HUB: Used to control node behavior (e.g., change reporting interval).
+     * For NODE: Can be used to request actions from the HUB.
+     *
+     * @param dest_node_id ID of the destination node.
+     * @param command_type Type of command to execute.
+     * @param payload Optional payload for the command.
+     * @param len Length of the payload.
+     * @param require_ack If true, waits for a logical acknowledgment.
+     * @return ESP_OK on success, or error code.
+     */
     virtual esp_err_t send_command(NodeId dest_node_id,
                                    CommandType command_type,
                                    const void *payload,
                                    size_t len,
                                    bool require_ack = false) = 0;
 
+    /**
+     * @brief Template overload for send_command using enum for NodeId
+     *
+     * @tparam T Enum type for NodeId.
+     * @param dest_node_id Destination node ID.
+     * @param command_type Command type.
+     * @param payload Command payload.
+     * @param len Payload length.
+     * @param require_ack Logical ACK request.
+     * @return esp_err_t result.
+     */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     esp_err_t send_command(T dest_node_id,
                            CommandType command_type,
@@ -47,10 +142,45 @@ public:
         return send_command(static_cast<NodeId>(dest_node_id), command_type, payload, len, require_ack);
     }
 
+    /**
+     * @brief Confirm the reception of a message that required an ACK
+     *
+     * Sends a logical acknowledgment back to the sender of the last received message that had the `require_ack` flag set.
+     * This should be called by the application after successfully processing the received data.
+     *
+     * @param status Status of the processing (e.g., SUCCESS or FAILURE).
+     * @return ESP_OK if ACK was sent, ESP_ERR_INVALID_STATE if no message is pending ACK.
+     */
     virtual esp_err_t confirm_reception(AckStatus status) = 0;
 
+    // ========================================
+    // Peer Management
+    // ========================================
+
+    /**
+     * @brief Manually add a peer to the manager
+     *
+     * Registers a node in the internal peer list and adds it to the ESP-NOW driver's peer table.
+     *
+     * @param node_id Unique ID of the node.
+     * @param mac MAC address of the node (6 bytes).
+     * @param channel WiFi channel the node is operating on.
+     * @param type Role/Type of the node.
+     * @return ESP_OK on success, or error if peer table is full.
+     */
     virtual esp_err_t add_peer(NodeId node_id, const uint8_t *mac, uint8_t channel, NodeType type) = 0;
 
+    /**
+     * @brief Template overload for add_peer using enums
+     *
+     * @tparam T1 Enum type for NodeId.
+     * @tparam T2 Enum type for NodeType.
+     * @param node_id Node ID.
+     * @param mac MAC address.
+     * @param channel WiFi channel.
+     * @param type Node type.
+     * @return esp_err_t result.
+     */
     template <typename T1,
               typename T2,
               typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
@@ -60,16 +190,68 @@ public:
         return add_peer(static_cast<NodeId>(node_id), mac, channel, static_cast<NodeType>(type));
     }
 
+    /**
+     * @brief Remove a peer from the manager
+     *
+     * Removes the peer from both internal lists and the ESP-NOW driver.
+     *
+     * @param node_id ID of the node to remove.
+     * @return ESP_OK on success, ESP_ERR_NOT_FOUND if not present.
+     */
     virtual esp_err_t remove_peer(NodeId node_id) = 0;
 
+    /**
+     * @brief Template overload for remove_peer using enum
+     *
+     * @tparam T Enum type for NodeId.
+     * @param node_id Node ID.
+     * @return esp_err_t result.
+     */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     esp_err_t remove_peer(T node_id)
     {
         return remove_peer(static_cast<NodeId>(node_id));
     }
 
-    virtual std::vector<PeerInfo> get_peers()                    = 0;
-    virtual std::vector<NodeId> get_offline_peers() const        = 0;
+    /**
+     * @brief Get a list of all registered peers
+     *
+     * @return Vector containing information for all registered peers.
+     */
+    virtual std::vector<PeerInfo> get_peers() = 0;
+
+    /**
+     * @brief Get a list of IDs for peers considered offline
+     *
+     * A peer is considered offline if no heartbeat has been received within its expected interval.
+     *
+     * @return Vector of Node IDs.
+     */
+    virtual std::vector<NodeId> get_offline_peers() const = 0;
+
+    // ========================================
+    // Pairing
+    // ========================================
+
+    /**
+     * @brief Start the pairing process
+     *
+     * For HUB: Enters a mode where it accepts pairing requests from new nodes.
+     * For NODE: Starts broadcasting pairing requests to find a HUB.
+     *
+     * @param timeout_ms Duration of the pairing mode in milliseconds.
+     * @return ESP_OK if pairing started successfully.
+     */
     virtual esp_err_t start_pairing(uint32_t timeout_ms = 30000) = 0;
-    virtual bool is_initialized() const                          = 0;
+
+    // ========================================
+    // Status
+    // ========================================
+
+    /**
+     * @brief Check if the manager is initialized
+     *
+     * @return true if initialized, false otherwise.
+     */
+    virtual bool is_initialized() const = 0;
 };

--- a/include/espnow_manager_interface.hpp
+++ b/include/espnow_manager_interface.hpp
@@ -70,7 +70,7 @@ public:
     // ========================================
 
     /**
-     * @brief Send data to a destination node
+     * @brief Send data to a destination node 
      *
      * Encapsulates the payload into a standard message format and queues it for transmission.
      * For HUB: Used to send application data to a specific registered node.
@@ -85,6 +85,7 @@ public:
      * @return ESP_ERR_NOT_FOUND: the peer is not registered.
      * @return ESP_ERR_INVALID_ARG: the packet is empty.
      * @return ESP_ERR_TIMEOUT: ACK timeout (when require_ack=true).
+     * @return ESP_FAIL: failed to send message to tx_queue_
      *
      * @note Non-blocking unless require_ack=true
      * @note Enter in channel SCANNING mode after MAX_PHYSICAL_FAILURES or MAX_LOGICAL_RETRIES
@@ -132,6 +133,7 @@ public:
      * @return ESP_ERR_NOT_FOUND: the peer is not registered.
      * @return ESP_ERR_INVALID_ARG: the packet is empty.
      * @return ESP_ERR_TIMEOUT: ACK timeout (when require_ack=true).
+     * @return ESP_FAIL: failed to send message to tx_queue_
      *
      * @note Non-blocking unless require_ack=true
      * @note Enter in channel SCANNING mode after MAX_PHYSICAL_FAILURES or MAX_LOGICAL_RETRIES
@@ -189,7 +191,7 @@ public:
      * @return Other: error from the ESP-NOW driver
      *
      * @note List uses LRU (Least Recently Used) policy with maximum MAX_PEERS = 19 (ESP-NOW limitation)
-     * @note When full, oldest peer (least recently used) is evicted automatically
+     * @note When full, oldest peer (least recently used) is removed to make room
      * @note Re-adding existing peer moves it to front (marks as recently used)
      * @note Automatically persisted to RTC and NVS storage if is a new peer or readding one with different mac or wifi
      * channel

--- a/include/espnow_manager_interface.hpp
+++ b/include/espnow_manager_interface.hpp
@@ -13,12 +13,13 @@
 
 /**
  * @interface IEspNowManager
- * @brief Interface for the ESP-NOW Manager, providing high-level APIs for communication, peer management, and lifecycle.
+ * @brief Interface for the ESP-NOW Manager, providing high-level APIs for communication, peer management, and
+ * lifecycle.
  *
  * This interface defines the contract for managing ESP-NOW communications in a structured way,
  * supporting both HUB (central controller) and NODE (peripheral) roles.
  *
- * @author Jules
+ * @author [github.com/aluiziotomazelli]
  * @version 1.0.0
  * @date 2025
  * @see EspNow for implementation details
@@ -41,8 +42,15 @@ public:
      * For NODE: Prepares to communicate with the HUB and optionally starts heartbeats.
      *
      * @param config Configuration structure containing node ID, type, and resource settings.
-     * @return ESP_OK on success, or an error code from the underlying ESP-IDF drivers.
+     * @return ESP_OK on success
+     * @return ESP_ERR_INVALID_STATE: already initialized or wifi_set_mode == WIFI_MODE_NULL
+     * @return ESP_ERR_INVALID_ARG: app_rx_queue is null (not initialized and passed as argument)
+     * @return ESP_ERR_NO_MEM: memory allocation for mutex and internal queues fails
+     * @return ESP_FAIL: failed to create internal tasks
+     * @return Other: internal esp_now.h or esp_wifi.h errors
+     *
      * @note This method must be called before any other operation.
+     * @note On fail, deinit() is called automatically.
      */
     virtual esp_err_t init(const EspNowConfig &config) = 0;
 
@@ -51,7 +59,9 @@ public:
      *
      * Stops all background tasks, releases memory, and deinitializes the ESP-NOW driver.
      *
-     * @return ESP_OK on success, or an error code if deinitialization fails.
+     * @return ESP_OK on success.
+     *
+     * @note Idempotent if is already deinitialized.
      */
     virtual esp_err_t deinit() = 0;
 
@@ -71,34 +81,39 @@ public:
      * @param payload Pointer to the data buffer to be sent.
      * @param len Length of the payload in bytes.
      * @param require_ack If true, the transmission will wait for a logical acknowledgment.
-     * @return ESP_OK if the packet was successfully queued, ESP_ERR_NOT_FOUND if the peer is not registered.
+     * @return ESP_OK: the packet was successfully queued.
+     * @return ESP_ERR_NOT_FOUND: the peer is not registered.
+     * @return ESP_ERR_INVALID_ARG: the packet is empty.
+     * @return ESP_ERR_TIMEOUT: ACK timeout (when require_ack=true).
+     *
+     * @note Non-blocking unless require_ack=true
+     * @note Enter in channel SCANNING mode after MAX_PHYSICAL_FAILURES or MAX_LOGICAL_RETRIES
+     *
+     * @warning Maximum payload: 230 bytes (ESP-NOW limit - header - CRC)
      */
-    virtual esp_err_t send_data(NodeId dest_node_id,
-                                PayloadType payload_type,
-                                const void *payload,
-                                size_t len,
-                                bool require_ack = false) = 0;
+    virtual esp_err_t send_data(
+        NodeId dest_node_id,
+        PayloadType payload_type,
+        const void *payload,
+        size_t len,
+        bool require_ack = false) = 0;
 
     /**
      * @brief Template overload for send_data using enum types
      *
      * @tparam T1 Enum type for NodeId.
      * @tparam T2 Enum type for PayloadType.
-     * @param dest_node_id Destination node ID.
-     * @param payload_type Payload type.
-     * @param payload Pointer to the data.
-     * @param len Data length.
-     * @param require_ack Logical ACK request.
-     * @return esp_err_t result.
+     * @see send_data() for full documentation
      */
-    template <typename T1,
-              typename T2,
-              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
-              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(PayloadType)>>
+    template <
+        typename T1,
+        typename T2,
+        typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+        typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(PayloadType)>>
     esp_err_t send_data(T1 dest_node_id, T2 payload_type, const void *payload, size_t len, bool require_ack = false)
     {
-        return send_data(static_cast<NodeId>(dest_node_id), static_cast<PayloadType>(payload_type), payload, len,
-                         require_ack);
+        return send_data(
+            static_cast<NodeId>(dest_node_id), static_cast<PayloadType>(payload_type), payload, len, require_ack);
     }
 
     /**
@@ -113,31 +128,32 @@ public:
      * @param payload Optional payload for the command.
      * @param len Length of the payload.
      * @param require_ack If true, waits for a logical acknowledgment.
-     * @return ESP_OK on success, or error code.
+     * @return ESP_OK: on success.
+     * @return ESP_ERR_NOT_FOUND: the peer is not registered.
+     * @return ESP_ERR_INVALID_ARG: the packet is empty.
+     * @return ESP_ERR_TIMEOUT: ACK timeout (when require_ack=true).
+     *
+     * @note Non-blocking unless require_ack=true
+     * @note Enter in channel SCANNING mode after MAX_PHYSICAL_FAILURES or MAX_LOGICAL_RETRIES
+     *
+     * @warning Maximum payload: 230 bytes (ESP-NOW limit - header - CRC)
      */
-    virtual esp_err_t send_command(NodeId dest_node_id,
-                                   CommandType command_type,
-                                   const void *payload,
-                                   size_t len,
-                                   bool require_ack = false) = 0;
+    virtual esp_err_t send_command(
+        NodeId dest_node_id,
+        CommandType command_type,
+        const void *payload,
+        size_t len,
+        bool require_ack = false) = 0;
 
     /**
      * @brief Template overload for send_command using enum for NodeId
      *
      * @tparam T Enum type for NodeId.
-     * @param dest_node_id Destination node ID.
-     * @param command_type Command type.
-     * @param payload Command payload.
-     * @param len Payload length.
-     * @param require_ack Logical ACK request.
-     * @return esp_err_t result.
+     * @see send_command() for full documentation
      */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
-    esp_err_t send_command(T dest_node_id,
-                           CommandType command_type,
-                           const void *payload,
-                           size_t len,
-                           bool require_ack = false)
+    esp_err_t
+    send_command(T dest_node_id, CommandType command_type, const void *payload, size_t len, bool require_ack = false)
     {
         return send_command(static_cast<NodeId>(dest_node_id), command_type, payload, len, require_ack);
     }
@@ -145,11 +161,12 @@ public:
     /**
      * @brief Confirm the reception of a message that required an ACK
      *
-     * Sends a logical acknowledgment back to the sender of the last received message that had the `require_ack` flag set.
-     * This should be called by the application after successfully processing the received data.
+     * Sends a logical acknowledgment back to the sender of the last received message that had the `require_ack` flag
+     * set. This should be called by the application after successfully processing the received data.
      *
-     * @param status Status of the processing (e.g., SUCCESS or FAILURE).
-     * @return ESP_OK if ACK was sent, ESP_ERR_INVALID_STATE if no message is pending ACK.
+     * @param status Status of the processing: OK, ERROR_INVALID_DATA or ERROR_PROCESSING
+     * @return ESP_OK: ACK was sent.
+     * @return ESP_ERR_INVALID_STATE: no message is pending ACK.
      */
     virtual esp_err_t confirm_reception(AckStatus status) = 0;
 
@@ -166,7 +183,18 @@ public:
      * @param mac MAC address of the node (6 bytes).
      * @param channel WiFi channel the node is operating on.
      * @param type Role/Type of the node.
-     * @return ESP_OK on success, or error if peer table is full.
+     * @return ESP_OK: on success.
+     * @return ESP_ERR_INVALID_ARG: mac is nullptr
+     * @return ESP_ERR_TIMEOUT: method timed out to get the mutex_
+     * @return Other: error from the ESP-NOW driver
+     *
+     * @note List uses LRU (Least Recently Used) policy with maximum MAX_PEERS = 19 (ESP-NOW limitation)
+     * @note When full, oldest peer (least recently used) is evicted automatically
+     * @note Re-adding existing peer moves it to front (marks as recently used)
+     * @note Automatically persisted to RTC and NVS storage if is a new peer or readding one with different mac or wifi
+     * channel
+     *
+     * @warning ESP-NOW hardware limit is 20 peers, but 1 is reserved for broadcast
      */
     virtual esp_err_t add_peer(NodeId node_id, const uint8_t *mac, uint8_t channel, NodeType type) = 0;
 
@@ -175,16 +203,13 @@ public:
      *
      * @tparam T1 Enum type for NodeId.
      * @tparam T2 Enum type for NodeType.
-     * @param node_id Node ID.
-     * @param mac MAC address.
-     * @param channel WiFi channel.
-     * @param type Node type.
-     * @return esp_err_t result.
+     * @see add_peer() for full documentation
      */
-    template <typename T1,
-              typename T2,
-              typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
-              typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
+    template <
+        typename T1,
+        typename T2,
+        typename = std::enable_if_t<std::is_enum_v<T1> && sizeof(T1) == sizeof(NodeId)>,
+        typename = std::enable_if_t<std::is_enum_v<T2> && sizeof(T2) == sizeof(NodeType)>>
     esp_err_t add_peer(T1 node_id, const uint8_t *mac, uint8_t channel, T2 type)
     {
         return add_peer(static_cast<NodeId>(node_id), mac, channel, static_cast<NodeType>(type));
@@ -196,7 +221,9 @@ public:
      * Removes the peer from both internal lists and the ESP-NOW driver.
      *
      * @param node_id ID of the node to remove.
-     * @return ESP_OK on success, ESP_ERR_NOT_FOUND if not present.
+     * @return ESP_OK: on success.
+     * @return ESP_ERR_NOT_FOUND: the peer is not present.
+     * @return ESP_ERR_TIMEOUT: method timed out to get the mutex_
      */
     virtual esp_err_t remove_peer(NodeId node_id) = 0;
 
@@ -204,8 +231,7 @@ public:
      * @brief Template overload for remove_peer using enum
      *
      * @tparam T Enum type for NodeId.
-     * @param node_id Node ID.
-     * @return esp_err_t result.
+     * @see remove_peer() for full documentation
      */
     template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
     esp_err_t remove_peer(T node_id)
@@ -236,11 +262,23 @@ public:
     /**
      * @brief Start the pairing process
      *
-     * For HUB: Enters a mode where it accepts pairing requests from new nodes.
-     * For NODE: Starts broadcasting pairing requests to find a HUB.
+     * **For HUB:**
+     * - Enters listening mode for pairing requests
+     * - Accepts requests from any node broadcasting
+     * - Automatically adds responding peers to peer list
+     *
+     * **For NODE:**
+     * - Broadcasts pairing request periodically (every 1s)
+     * - Waits for HUB to respond with acknowledgment
+     * - Automatically stops when paired or timeout reached
      *
      * @param timeout_ms Duration of the pairing mode in milliseconds.
-     * @return ESP_OK if pairing started successfully.
+     * @return ESP_OK: pairing started successfully.
+     * @return ESP_ERR_INVALID_STATE: pairing is already active.
+     *
+     * @note Automatic stop after specified timeout duration
+     *
+     * @warning Both HUB and NODE must be in pairing mode simultaneously
      */
     virtual esp_err_t start_pairing(uint32_t timeout_ms = 30000) = 0;
 

--- a/include/espnow_storage.hpp
+++ b/include/espnow_storage.hpp
@@ -33,8 +33,9 @@ struct PersistentData
 class EspNowStorage : public IStorage
 {
 public:
-    EspNowStorage(std::unique_ptr<IPersistenceBackend> rtc_backend = nullptr,
-                  std::unique_ptr<IPersistenceBackend> nvs_backend = nullptr);
+    EspNowStorage(
+        std::unique_ptr<IPersistenceBackend> rtc_backend = nullptr,
+        std::unique_ptr<IPersistenceBackend> nvs_backend = nullptr);
     ~EspNowStorage();
 
     /**
@@ -55,9 +56,8 @@ public:
      * unchanged.
      * @return ESP_OK if saved successfully, error otherwise.
      */
-    esp_err_t save(uint8_t wifi_channel,
-                   const std::vector<PersistentPeer> &peers,
-                   bool force_nvs_commit = true) override;
+    esp_err_t
+    save(uint8_t wifi_channel, const std::vector<PersistentPeer> &peers, bool force_nvs_commit = true) override;
 
 private:
     uint32_t calculate_crc(const PersistentData &data);

--- a/include/espnow_types.hpp
+++ b/include/espnow_types.hpp
@@ -22,11 +22,11 @@ constexpr int MAX_PEERS = 19;
  */
 struct RxPacket
 {
-    uint8_t src_mac[6];                  /**< Source MAC address of the sender */
+    uint8_t src_mac[6];                 /**< Source MAC address of the sender */
     uint8_t data[ESP_NOW_MAX_DATA_LEN]; /**< Raw payload data */
-    size_t len;                          /**< Length of the payload in bytes */
-    int8_t rssi;                         /**< Received Signal Strength Indicator (dBm) */
-    int64_t timestamp_us;                /**< Microsecond timestamp (esp_timer_get_time) */
+    size_t len;                         /**< Length of the payload in bytes */
+    int8_t rssi;                        /**< Received Signal Strength Indicator (dBm) */
+    int64_t timestamp_us;               /**< Microsecond timestamp (esp_timer_get_time) */
 };
 
 /**

--- a/include/espnow_types.hpp
+++ b/include/espnow_types.hpp
@@ -9,85 +9,109 @@
 
 #include "protocol_types.hpp"
 
+/**
+ * @file espnow_types.hpp
+ * @brief Internal and public data structures for the EspNowManager component.
+ */
+
+/** @brief Maximum number of peers that can be registered in the manager */
 constexpr int MAX_PEERS = 19;
 
-// Generic structure for received packets
+/**
+ * @brief Generic structure for packets received from the ESP-NOW layer.
+ */
 struct RxPacket
 {
-    uint8_t src_mac[6];
-    uint8_t data[ESP_NOW_MAX_DATA_LEN];
-    size_t len;
-    int8_t rssi;
-    int64_t timestamp_us;
-};
-
-// Public information about a peer
-struct PeerInfo
-{
-    uint8_t mac[6];
-    NodeType type;
-    NodeId node_id;
-    uint8_t channel;
-    uint64_t last_seen_ms;
-    bool paired;
-    uint32_t heartbeat_interval_ms;
+    uint8_t src_mac[6];                  /**< Source MAC address of the sender */
+    uint8_t data[ESP_NOW_MAX_DATA_LEN]; /**< Raw payload data */
+    size_t len;                          /**< Length of the payload in bytes */
+    int8_t rssi;                         /**< Received Signal Strength Indicator (dBm) */
+    int64_t timestamp_us;                /**< Microsecond timestamp (esp_timer_get_time) */
 };
 
 /**
- * @brief Peer information to be persisted.
+ * @brief Detailed information about a registered peer.
+ */
+struct PeerInfo
+{
+    uint8_t mac[6];                 /**< 6-byte MAC address of the peer */
+    NodeType type;                  /**< Categorization of the node (e.g., HUB or peripheral) */
+    NodeId node_id;                 /**< Unique logical ID assigned to the node */
+    uint8_t channel;                /**< WiFi channel the peer is currently using */
+    uint64_t last_seen_ms;          /**< Timestamp of the last message received (ms) */
+    bool paired;                    /**< If true, the node has completed the pairing process */
+    uint32_t heartbeat_interval_ms; /**< Expected frequency of heartbeat messages */
+};
+
+/**
+ * @brief Peer information optimized for persistent storage (NVS/RTC).
  */
 struct PersistentPeer
 {
-    uint8_t mac[6];
-    NodeType type;
-    NodeId node_id;
-    uint8_t channel;
-    bool paired;
-    uint32_t heartbeat_interval_ms;
+    uint8_t mac[6];                 /**< 6-byte MAC address */
+    NodeType type;                  /**< Node type */
+    NodeId node_id;                 /**< Logical Node ID */
+    uint8_t channel;                /**< Operating WiFi channel */
+    bool paired;                    /**< Pairing status */
+    uint32_t heartbeat_interval_ms; /**< Configured heartbeat interval */
 };
 
 // --- FSM and TX Task Structures ---
+
+/**
+ * @brief Structure for packets queued for transmission.
+ */
 struct TxPacket
 {
-    uint8_t dest_mac[6];
-    uint8_t data[ESP_NOW_MAX_DATA_LEN];
-    size_t len;
-    bool requires_ack;
+    uint8_t dest_mac[6];                /**< Destination MAC address (or BROADCAST) */
+    uint8_t data[ESP_NOW_MAX_DATA_LEN]; /**< Raw data to be sent */
+    size_t len;                         /**< Length of the data in bytes */
+    bool requires_ack;                  /**< If true, logic will wait for a confirm_reception() */
 };
 
+/**
+ * @brief Enumeration of internal transmission states.
+ */
 enum class TxState
 {
-    IDLE,
-    SENDING,
-    WAITING_FOR_ACK,
-    RETRYING,
-    SCANNING
+    IDLE,            /**< No active transmission */
+    SENDING,         /**< Waiting for the physical ESP-NOW callback */
+    WAITING_FOR_ACK, /**< Physical send success, waiting for logical AckMessage */
+    RETRYING,        /**< Waiting before attempting a retransmission */
+    SCANNING         /**< Performing a channel scan to locate the destination */
 };
 
+/**
+ * @brief Internal tracking structure for messages waiting for an acknowledgment.
+ */
 struct PendingAck
 {
-    uint16_t sequence_number;
-    uint64_t timestamp_ms;
-    uint8_t retries_left;
-    TxPacket packet;
-    NodeId node_id;
+    uint16_t sequence_number; /**< Sequence number of the message being tracked */
+    uint64_t timestamp_ms;    /**< Timestamp of the last attempt (ms) */
+    uint8_t retries_left;     /**< Remaining retransmission attempts */
+    TxPacket packet;          /**< Copy of the packet to allow retransmission */
+    NodeId node_id;           /**< Target Node ID for tracking and timeout logic */
 };
 
-// Configuration to initialize the EspNowManager component
+/**
+ * @brief Configuration structure for initializing the EspNowManager.
+ */
 struct EspNowConfig
 {
-    NodeId node_id;
-    NodeType node_type;
-    QueueHandle_t app_rx_queue;
-    uint8_t wifi_channel;
-    uint32_t ack_timeout_ms;
-    uint32_t heartbeat_interval_ms;
+    NodeId node_id;                 /**< Logical ID for this device */
+    NodeType node_type;             /**< Role/Type for this device */
+    QueueHandle_t app_rx_queue;     /**< Handle to the application queue where incoming DATA/COMMANDS are posted */
+    uint8_t wifi_channel;           /**< Initial WiFi channel to operate on */
+    uint32_t ack_timeout_ms;        /**< Timeout for logical acknowledgments (ms) */
+    uint32_t heartbeat_interval_ms; /**< Interval for heartbeats; 0 disables generation (ms) */
 
-    uint32_t stack_size_rx_dispatch;
-    uint32_t stack_size_transport_worker;
-    uint32_t stack_size_tx_manager;
+    uint32_t stack_size_rx_dispatch;      /**< Stack size for the internal packet dispatcher task */
+    uint32_t stack_size_transport_worker; /**< Stack size for the worker task (Heartbeats, Pairing) */
+    uint32_t stack_size_tx_manager;       /**< Stack size for the transmission manager task */
 
-    // Default constructor
+    /**
+     * @brief Default constructor with sensible defaults.
+     */
     EspNowConfig()
         : node_id(ReservedIds::HUB)
         , node_type(ReservedTypes::UNKNOWN)

--- a/include/message_router.hpp
+++ b/include/message_router.hpp
@@ -7,11 +7,12 @@
 class RealMessageRouter : public IMessageRouter
 {
 public:
-    RealMessageRouter(IPeerManager &peer_manager,
-                      ITxManager &tx_manager,
-                      IHeartbeatManager &heartbeat_manager,
-                      IPairingManager &pairing_manager,
-                      IMessageCodec &message_codec);
+    RealMessageRouter(
+        IPeerManager &peer_manager,
+        ITxManager &tx_manager,
+        IHeartbeatManager &heartbeat_manager,
+        IPairingManager &pairing_manager,
+        IMessageCodec &message_codec);
 
     void set_app_queue(QueueHandle_t app_queue) override
     {

--- a/include/peer_manager.hpp
+++ b/include/peer_manager.hpp
@@ -18,11 +18,8 @@ public:
     using IPeerManager::remove;
     using IPeerManager::update_last_seen;
 
-    esp_err_t add(NodeId id,
-                  const uint8_t *mac,
-                  uint8_t channel,
-                  NodeType type,
-                  uint32_t heartbeat_interval_ms = 0) override;
+    esp_err_t
+    add(NodeId id, const uint8_t *mac, uint8_t channel, NodeType type, uint32_t heartbeat_interval_ms = 0) override;
     esp_err_t remove(NodeId id) override;
     bool find_mac(NodeId id, uint8_t *mac) override;
     std::vector<PeerInfo> get_all() override;

--- a/include/protocol_messages.hpp
+++ b/include/protocol_messages.hpp
@@ -2,72 +2,102 @@
 
 #include "protocol_types.hpp"
 
+/**
+ * @file protocol_messages.hpp
+ * @brief Definition of protocol message structures for ESP-NOW communication.
+ *
+ * All structures in this file use 1-byte packing to ensure consistent memory layout
+ * across different compilers and architectures.
+ */
+
 #pragma pack(push, 1)
 
-// ========== HEADER UNIVERSAL ==========
+/**
+ * @brief Universal header included at the beginning of every packet.
+ */
 struct MessageHeader
 {
-    MessageType msg_type;
-    uint16_t sequence_number;
-    NodeType sender_type;
-    NodeId sender_node_id;
-    PayloadType payload_type;
-    bool requires_ack;
-    NodeId dest_node_id;
-    uint64_t timestamp_ms;
+    MessageType msg_type;     /**< Type identifier for the message */
+    uint16_t sequence_number; /**< Incremental sequence number for tracking and deduplication */
+    NodeType sender_type;     /**< Type/Role of the sending node */
+    NodeId sender_node_id;    /**< Unique ID of the sending node */
+    PayloadType payload_type; /**< Identifier for the content format (for DATA/COMMAND) */
+    bool requires_ack;        /**< If true, the receiver should send an ACK message */
+    NodeId dest_node_id;      /**< Unique ID of the destination node (or BROADCAST) */
+    uint64_t timestamp_ms;    /**< Millisecond timestamp of when the message was sent */
 };
 
 // ========== TRANSPORT LAYER ==========
+
+/**
+ * @brief Packet sent by a Node to request pairing with a Hub.
+ */
 struct PairRequest
 {
-    MessageHeader header;
-    uint8_t firmware_version[3];
-    uint64_t uptime_ms;
-    char device_name[16];
-    uint32_t heartbeat_interval_ms;
+    MessageHeader header;            /**< Universal message header */
+    uint8_t firmware_version[3];     /**< Current firmware version of the node (major, minor, patch) */
+    uint64_t uptime_ms;              /**< Current uptime of the node in milliseconds */
+    char device_name[16];            /**< Human-readable name of the device */
+    uint32_t heartbeat_interval_ms; /**< Requested interval between heartbeats */
 };
 
+/**
+ * @brief Packet sent by the Hub in response to a PairRequest.
+ */
 struct PairResponse
 {
-    MessageHeader header;
-    PairStatus status;
-    NodeId assigned_id;
-    uint32_t heartbeat_interval_ms;
-    uint32_t report_interval_ms;
-    uint8_t wifi_channel;
+    MessageHeader header;            /**< Universal message header */
+    PairStatus status;               /**< Acceptance or rejection status */
+    NodeId assigned_id;              /**< Node ID assigned by the Hub (if accepted) */
+    uint32_t heartbeat_interval_ms; /**< Heartbeat interval authorized by the Hub */
+    uint32_t report_interval_ms;    /**< Suggested reporting interval for application data */
+    uint8_t wifi_channel;            /**< WiFi channel the Hub is operating on */
 };
 
+/**
+ * @brief Periodic packet sent by a Node to maintain its 'online' status.
+ */
 struct HeartbeatMessage
 {
-    MessageHeader header;
-    uint16_t battery_mv;
-    int8_t rssi;
-    uint64_t uptime_ms;
+    MessageHeader header; /**< Universal message header */
+    uint16_t battery_mv;  /**< Current battery voltage in millivolts */
+    int8_t rssi;          /**< RSSI of the Hub as seen by the Node (from last reception) */
+    uint64_t uptime_ms;   /**< Current uptime of the node in milliseconds */
 };
 
+/**
+ * @brief Packet sent by the Hub as an immediate response to a HeartbeatMessage.
+ */
 struct HeartbeatResponse
 {
-    MessageHeader header;
-    uint64_t server_time_ms;
-    uint8_t wifi_channel;
+    MessageHeader header;     /**< Universal message header */
+    uint64_t server_time_ms;  /**< Current Unix epoch or relative server time in milliseconds */
+    uint8_t wifi_channel;     /**< Current WiFi channel of the Hub (for channel synchronization) */
 };
 
 // ========== APPLICATION LAYER ==========
+
+/**
+ * @brief Packet sent to acknowledge receipt of a DATA or COMMAND message.
+ */
 struct AckMessage
 {
-    MessageHeader header;
-    uint16_t ack_sequence;
-    AckStatus status;
-    uint32_t processing_time_us;
+    MessageHeader header;       /**< Universal message header */
+    uint16_t ack_sequence;      /**< Sequence number of the message being acknowledged */
+    AckStatus status;           /**< Processing status of the acknowledged message */
+    uint32_t processing_time_us; /**< Time taken to process the message in microseconds */
 };
 
+/**
+ * @brief Packet sent to initiate or manage an OTA update.
+ */
 struct OtaCommand
 {
-    MessageHeader header;
-    CommandType cmd_type;
-    char firmware_url[128];
-    uint32_t firmware_size;
-    uint8_t firmware_hash[32];
+    MessageHeader header;      /**< Universal message header */
+    CommandType cmd_type;      /**< Type of OTA command (e.g., START) */
+    char firmware_url[128];    /**< URL where the node can download the new firmware */
+    uint32_t firmware_size;    /**< Expected size of the firmware binary in bytes */
+    uint8_t firmware_hash[32]; /**< SHA-256 hash of the firmware binary for validation */
 };
 
 #pragma pack(pop)

--- a/include/protocol_messages.hpp
+++ b/include/protocol_messages.hpp
@@ -34,10 +34,10 @@ struct MessageHeader
  */
 struct PairRequest
 {
-    MessageHeader header;            /**< Universal message header */
-    uint8_t firmware_version[3];     /**< Current firmware version of the node (major, minor, patch) */
-    uint64_t uptime_ms;              /**< Current uptime of the node in milliseconds */
-    char device_name[16];            /**< Human-readable name of the device */
+    MessageHeader header;           /**< Universal message header */
+    uint8_t firmware_version[3];    /**< Current firmware version of the node (major, minor, patch) */
+    uint64_t uptime_ms;             /**< Current uptime of the node in milliseconds */
+    char device_name[16];           /**< Human-readable name of the device */
     uint32_t heartbeat_interval_ms; /**< Requested interval between heartbeats */
 };
 
@@ -46,12 +46,12 @@ struct PairRequest
  */
 struct PairResponse
 {
-    MessageHeader header;            /**< Universal message header */
-    PairStatus status;               /**< Acceptance or rejection status */
-    NodeId assigned_id;              /**< Node ID assigned by the Hub (if accepted) */
+    MessageHeader header;           /**< Universal message header */
+    PairStatus status;              /**< Acceptance or rejection status */
+    NodeId assigned_id;             /**< Node ID assigned by the Hub (if accepted) */
     uint32_t heartbeat_interval_ms; /**< Heartbeat interval authorized by the Hub */
     uint32_t report_interval_ms;    /**< Suggested reporting interval for application data */
-    uint8_t wifi_channel;            /**< WiFi channel the Hub is operating on */
+    uint8_t wifi_channel;           /**< WiFi channel the Hub is operating on */
 };
 
 /**
@@ -70,9 +70,9 @@ struct HeartbeatMessage
  */
 struct HeartbeatResponse
 {
-    MessageHeader header;     /**< Universal message header */
-    uint64_t server_time_ms;  /**< Current Unix epoch or relative server time in milliseconds */
-    uint8_t wifi_channel;     /**< Current WiFi channel of the Hub (for channel synchronization) */
+    MessageHeader header;    /**< Universal message header */
+    uint64_t server_time_ms; /**< Current Unix epoch or relative server time in milliseconds */
+    uint8_t wifi_channel;    /**< Current WiFi channel of the Hub (for channel synchronization) */
 };
 
 // ========== APPLICATION LAYER ==========
@@ -82,9 +82,9 @@ struct HeartbeatResponse
  */
 struct AckMessage
 {
-    MessageHeader header;       /**< Universal message header */
-    uint16_t ack_sequence;      /**< Sequence number of the message being acknowledged */
-    AckStatus status;           /**< Processing status of the acknowledged message */
+    MessageHeader header;        /**< Universal message header */
+    uint16_t ack_sequence;       /**< Sequence number of the message being acknowledged */
+    AckStatus status;            /**< Processing status of the acknowledged message */
     uint32_t processing_time_us; /**< Time taken to process the message in microseconds */
 };
 

--- a/include/protocol_types.hpp
+++ b/include/protocol_types.hpp
@@ -6,90 +6,138 @@
 
 #include "esp_now.h"
 
-// Correct size of the universal message header
+/**
+ * @file protocol_types.hpp
+ * @brief Common protocol types and constants for ESP-NOW communication.
+ */
+
+/** @brief Correct size of the universal message header */
 constexpr size_t MESSAGE_HEADER_SIZE = 16;
+/** @brief Size of the CRC field in the packet */
 constexpr size_t CRC_SIZE            = 1;
-// The maximum payload size is the total ESP-NOW size minus the header and CRC
+/** @brief The maximum payload size is the total ESP-NOW size minus the header and CRC */
 constexpr size_t MAX_PAYLOAD_SIZE = ESP_NOW_MAX_DATA_LEN - MESSAGE_HEADER_SIZE - CRC_SIZE;
 
 // Default values (can be overridden in config)
+/** @brief Default acknowledgment timeout in milliseconds */
 constexpr uint32_t DEFAULT_ACK_TIMEOUT_MS        = 500;
+/** @brief Default interval between heartbeat messages in milliseconds */
 constexpr uint32_t DEFAULT_HEARTBEAT_INTERVAL_MS = 60000;
+/** @brief Default WiFi channel to use if none is specified */
 constexpr uint8_t DEFAULT_WIFI_CHANNEL           = 1;
+/** @brief Multiplier applied to heartbeat interval to determine if a node is offline */
 constexpr float HEARTBEAT_OFFLINE_MULTIPLIER     = 2.5f;
 
 // Constants for retry logic
+/** @brief Timeout for logical acknowledgments in milliseconds */
 constexpr uint32_t LOGICAL_ACK_TIMEOUT_MS = 500;
+/** @brief Maximum number of logical retries for unacknowledged packets */
 constexpr uint8_t MAX_LOGICAL_RETRIES     = 3;
+/** @brief Maximum number of physical transmission failures before giving up or scanning */
 constexpr uint8_t MAX_PHYSICAL_FAILURES   = 3;
 
+/** @brief Timeout for scanning a single channel during discovery (ms) */
 constexpr uint16_t SCAN_CHANNEL_TIMEOUT_MS = 50;
+/** @brief Number of scan attempts per channel */
 constexpr uint8_t SCAN_CHANNEL_ATTEMPTS    = 2;
+/** @brief Total maximum time allowed for a full channel scan */
 constexpr uint16_t MAX_SCAN_TIME_MS        = SCAN_CHANNEL_TIMEOUT_MS * SCAN_CHANNEL_ATTEMPTS * 20;
 
-// Generic types for Node identification and categorization
+/** @brief Type alias for Node identification (0-255) */
 using NodeId      = uint8_t;
+/** @brief Type alias for Node role/category categorization */
 using NodeType    = uint8_t;
+/** @brief Type alias for application-defined payload identifiers */
 using PayloadType = uint8_t;
 
+/**
+ * @brief Reserved Node IDs with special meanings.
+ */
 namespace ReservedIds {
+/** @brief Broadcast ID for sending to all nodes */
 constexpr NodeId BROADCAST = 0xFF;
+/** @brief Central Hub/Controller default ID */
 constexpr NodeId HUB       = 0x01;
 } // namespace ReservedIds
 
+/**
+ * @brief Reserved Node Types for core functionality.
+ */
 namespace ReservedTypes {
+/** @brief Type for nodes that have not yet identified themselves */
 constexpr NodeType UNKNOWN = 0x00;
+/** @brief Type identifier for the Central Hub */
 constexpr NodeType HUB     = 0x01;
 } // namespace ReservedTypes
 
-// Bridge templates for type-safe enum usage
+/**
+ * @brief Bridge template for type-safe NodeId conversion from enums
+ */
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeId)>>
 constexpr NodeId to_node_id(T enum_val)
 {
     return static_cast<NodeId>(enum_val);
 }
 
+/**
+ * @brief Bridge template for type-safe NodeType conversion from enums
+ */
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(NodeType)>>
 constexpr NodeType to_node_type(T enum_val)
 {
     return static_cast<NodeType>(enum_val);
 }
 
+/**
+ * @brief Bridge template for type-safe PayloadType conversion from enums
+ */
 template <typename T, typename = std::enable_if_t<std::is_enum_v<T> && sizeof(T) == sizeof(PayloadType)>>
 constexpr PayloadType to_payload_type(T enum_val)
 {
     return static_cast<PayloadType>(enum_val);
 }
 
+/**
+ * @brief Enumeration of protocol-level message types.
+ */
 enum class MessageType : uint8_t
 {
-    PAIR_REQUEST          = 0x00,
-    PAIR_RESPONSE         = 0x01,
-    HEARTBEAT             = 0x02,
-    HEARTBEAT_RESPONSE    = 0x03,
-    DATA                  = 0x10,
-    ACK                   = 0x11,
-    COMMAND               = 0x20,
-    CHANNEL_SCAN_PROBE    = 0x30,
-    CHANNEL_SCAN_RESPONSE = 0x31,
+    PAIR_REQUEST          = 0x00, /**< Initial request from a Node to pair with a Hub */
+    PAIR_RESPONSE         = 0x01, /**< Response from the Hub to a pairing request */
+    HEARTBEAT             = 0x02, /**< Periodic keep-alive message from Node to Hub */
+    HEARTBEAT_RESPONSE    = 0x03, /**< Acknowledgment of heartbeat from Hub to Node */
+    DATA                  = 0x10, /**< Standard application data packet */
+    ACK                   = 0x11, /**< Logical acknowledgment for DATA or COMMAND packets */
+    COMMAND               = 0x20, /**< Control command sent from Hub to Node */
+    CHANNEL_SCAN_PROBE    = 0x30, /**< Broadcast probe sent during channel discovery */
+    CHANNEL_SCAN_RESPONSE = 0x31, /**< Response to a scan probe to identify active Hubs */
 };
 
+/**
+ * @brief Status codes for the pairing process.
+ */
 enum class PairStatus : uint8_t
 {
-    ACCEPTED             = 0x00,
-    REJECTED_NOT_ALLOWED = 0x01,
+    ACCEPTED             = 0x00, /**< Pairing successful; Node is registered */
+    REJECTED_NOT_ALLOWED = 0x01, /**< Pairing failed; registration not permitted */
 };
 
+/**
+ * @brief Logical acknowledgment status codes.
+ */
 enum class AckStatus : uint8_t
 {
-    OK                 = 0x00,
-    ERROR_INVALID_DATA = 0x01,
-    ERROR_PROCESSING   = 0x02,
+    OK                 = 0x00, /**< Message received and processed successfully */
+    ERROR_INVALID_DATA = 0x01, /**< Message received but payload data is invalid */
+    ERROR_PROCESSING   = 0x02, /**< Message received but processing failed internally */
 };
 
+/**
+ * @brief Enumeration of standard control commands.
+ */
 enum class CommandType : uint8_t
 {
-    START_OTA           = 0x01,
-    REBOOT              = 0x02,
-    SET_REPORT_INTERVAL = 0x03,
+    START_OTA           = 0x01, /**< Instructs the node to start an Over-The-Air update */
+    REBOOT              = 0x02, /**< Instructs the node to perform a system reset */
+    SET_REPORT_INTERVAL = 0x03, /**< Instructs the node to change its data reporting frequency */
 };

--- a/include/protocol_types.hpp
+++ b/include/protocol_types.hpp
@@ -14,39 +14,39 @@
 /** @brief Correct size of the universal message header */
 constexpr size_t MESSAGE_HEADER_SIZE = 16;
 /** @brief Size of the CRC field in the packet */
-constexpr size_t CRC_SIZE            = 1;
+constexpr size_t CRC_SIZE = 1;
 /** @brief The maximum payload size is the total ESP-NOW size minus the header and CRC */
 constexpr size_t MAX_PAYLOAD_SIZE = ESP_NOW_MAX_DATA_LEN - MESSAGE_HEADER_SIZE - CRC_SIZE;
 
 // Default values (can be overridden in config)
 /** @brief Default acknowledgment timeout in milliseconds */
-constexpr uint32_t DEFAULT_ACK_TIMEOUT_MS        = 500;
+constexpr uint32_t DEFAULT_ACK_TIMEOUT_MS = 500;
 /** @brief Default interval between heartbeat messages in milliseconds */
 constexpr uint32_t DEFAULT_HEARTBEAT_INTERVAL_MS = 60000;
 /** @brief Default WiFi channel to use if none is specified */
-constexpr uint8_t DEFAULT_WIFI_CHANNEL           = 1;
+constexpr uint8_t DEFAULT_WIFI_CHANNEL = 1;
 /** @brief Multiplier applied to heartbeat interval to determine if a node is offline */
-constexpr float HEARTBEAT_OFFLINE_MULTIPLIER     = 2.5f;
+constexpr float HEARTBEAT_OFFLINE_MULTIPLIER = 2.5f;
 
 // Constants for retry logic
 /** @brief Timeout for logical acknowledgments in milliseconds */
 constexpr uint32_t LOGICAL_ACK_TIMEOUT_MS = 500;
 /** @brief Maximum number of logical retries for unacknowledged packets */
-constexpr uint8_t MAX_LOGICAL_RETRIES     = 3;
+constexpr uint8_t MAX_LOGICAL_RETRIES = 3;
 /** @brief Maximum number of physical transmission failures before giving up or scanning */
-constexpr uint8_t MAX_PHYSICAL_FAILURES   = 3;
+constexpr uint8_t MAX_PHYSICAL_FAILURES = 3;
 
 /** @brief Timeout for scanning a single channel during discovery (ms) */
 constexpr uint16_t SCAN_CHANNEL_TIMEOUT_MS = 50;
 /** @brief Number of scan attempts per channel */
-constexpr uint8_t SCAN_CHANNEL_ATTEMPTS    = 2;
+constexpr uint8_t SCAN_CHANNEL_ATTEMPTS = 2;
 /** @brief Total maximum time allowed for a full channel scan */
-constexpr uint16_t MAX_SCAN_TIME_MS        = SCAN_CHANNEL_TIMEOUT_MS * SCAN_CHANNEL_ATTEMPTS * 20;
+constexpr uint16_t MAX_SCAN_TIME_MS = SCAN_CHANNEL_TIMEOUT_MS * SCAN_CHANNEL_ATTEMPTS * 20;
 
 /** @brief Type alias for Node identification (0-255) */
-using NodeId      = uint8_t;
+using NodeId = uint8_t;
 /** @brief Type alias for Node role/category categorization */
-using NodeType    = uint8_t;
+using NodeType = uint8_t;
 /** @brief Type alias for application-defined payload identifiers */
 using PayloadType = uint8_t;
 
@@ -57,7 +57,7 @@ namespace ReservedIds {
 /** @brief Broadcast ID for sending to all nodes */
 constexpr NodeId BROADCAST = 0xFF;
 /** @brief Central Hub/Controller default ID */
-constexpr NodeId HUB       = 0x01;
+constexpr NodeId HUB = 0x01;
 } // namespace ReservedIds
 
 /**
@@ -67,7 +67,7 @@ namespace ReservedTypes {
 /** @brief Type for nodes that have not yet identified themselves */
 constexpr NodeType UNKNOWN = 0x00;
 /** @brief Type identifier for the Central Hub */
-constexpr NodeType HUB     = 0x01;
+constexpr NodeType HUB = 0x01;
 } // namespace ReservedTypes
 
 /**

--- a/tx_manager.cpp
+++ b/tx_manager.cpp
@@ -79,7 +79,7 @@ esp_err_t RealTxManager::queue_packet(const TxPacket &packet)
     if (!tx_queue_)
         return ESP_ERR_INVALID_STATE;
     if (xQueueSend(tx_queue_, &packet, pdMS_TO_TICKS(100)) != pdTRUE) {
-        return ESP_ERR_TIMEOUT;
+        return ESP_FAIL;
     }
     if (task_handle_) {
         xTaskNotify(task_handle_, NOTIFY_DATA, eSetBits);


### PR DESCRIPTION
This change adds complete Doxygen documentation to the ESP-NOW management component. It documents both the public IEspNowManager interface and the internal component interfaces (IPeerManager, ITxManager, etc.), providing clear guidance on HUB vs NODE roles. Headers are organized with session separators for better readability, and implementation headers use @copydoc to link back to the interface documentation. Junk symlinks were also removed from the repository root.

---
*PR created automatically by Jules for task [11430818112181547790](https://jules.google.com/task/11430818112181547790) started by @aluiziotomazelli*