### PR TITLE
feat(stats): measure and track RTT in microseconds (us)

### DIFF
--- a/API.md
+++ b/API.md
@@ -806,8 +806,8 @@ Retrieves current link quality metrics for a specific peer identified by `node_i
 ```cpp
 espnow::PeerStatistics stats;
 if (manager.get_peer_stats(espnow::ReservedIds::HUB, stats)) {
-    ESP_LOGI(TAG, "HUB RSSI: %d dBm (avg), RTT: %lu ms",
-             stats.rssi_avg, (unsigned long)stats.rtt_avg_ms);
+    ESP_LOGI(TAG, "HUB RSSI: %d dBm (avg), RTT: %lu us",
+             stats.rssi_avg, (unsigned long)stats.rtt_avg_us);
     ESP_LOGI(TAG, "Packets: rx=%lu, tx=%lu, lost=%lu",
              (unsigned long)stats.packets_rx,
              (unsigned long)stats.packets_sent,
@@ -844,11 +844,11 @@ auto all_stats = manager.get_all_peer_stats();
 
 ESP_LOGI(TAG, "Tracking %d peers:", all_stats.size());
 for (const auto& stats : all_stats) {
-    ESP_LOGI(TAG, "  Node %d: RSSI=%d dBm, RTT=%lu ms, "
+    ESP_LOGI(TAG, "  Node %d: RSSI=%d dBm, RTT=%lu us, "
              "tx=%lu, rx=%lu, lost=%lu",
              stats.node_id,
              stats.rssi_avg,
-             (unsigned long)stats.rtt_avg_ms,
+             (unsigned long)stats.rtt_avg_us,
              (unsigned long)stats.packets_sent,
              (unsigned long)stats.packets_rx,
              (unsigned long)stats.packets_lost);
@@ -874,8 +874,8 @@ struct espnow::PeerStatistics
     uint32_t driver_errors;           ///< hal_esp_now_send() returned error
     uint32_t packets_lost;            ///< ACK timeouts after retries exhausted
     uint32_t retries;                 ///< Number of retransmissions
-    uint32_t rtt_last_ms;             ///< Last round-trip time (ms)
-    uint32_t rtt_avg_ms;              ///< Exponential moving average of RTT (0 = unknown)
+    uint32_t rtt_last_us;             ///< Last round-trip time (us)
+    uint32_t rtt_avg_us;              ///< Exponential moving average of RTT (0 = unknown)
 };
 ```
 
@@ -893,8 +893,8 @@ struct espnow::PeerStatistics
 | `driver_errors` | `uint32_t` | ESP-NOW driver send errors (NO_MEM, CHAN, etc.) |
 | `packets_lost` | `uint32_t` | Packets lost due to ACK timeout after all retries |
 | `retries` | `uint32_t` | Total retransmission attempts |
-| `rtt_last_ms` | `uint32_t` | Most recent round-trip time in milliseconds |
-| `rtt_avg_ms` | `uint32_t` | EMA-smoothed RTT average. `0` means no data yet |
+| `rtt_last_us` | `uint32_t` | Most recent round-trip time in microseconds |
+| `rtt_avg_us` | `uint32_t` | EMA-smoothed RTT average. `0` means no data yet |
 
 **EMA Details:**
 - RSSI alpha is derived from heartbeat interval: shorter intervals → smoother (less reactive)

--- a/host_test/common/mock_statistics_manager.hpp
+++ b/host_test/common/mock_statistics_manager.hpp
@@ -16,7 +16,7 @@ public:
     MOCK_METHOD(void, on_peer_removed, (NodeId node_id), (override));
 
     MOCK_METHOD(void, on_packet_received, (NodeId node_id, int8_t rssi), (override));
-    MOCK_METHOD(void, on_ack_received, (NodeId node_id, uint32_t rtt_ms), (override));
+    MOCK_METHOD(void, on_ack_received, (NodeId node_id, uint32_t rtt_us), (override));
 
     MOCK_METHOD(void, on_delivery_success, (NodeId node_id), (override));
     MOCK_METHOD(void, on_delivery_failure, (NodeId node_id), (override));

--- a/host_test/test_statistics_manager/main/test_statistics_manager.cpp
+++ b/host_test/test_statistics_manager/main/test_statistics_manager.cpp
@@ -82,8 +82,8 @@ TEST_F(StatisticsManagerTest, AckReceivedUpdatesRttAvg)
 
     // Assert
     auto all_stats = sut->get_all();
-    EXPECT_GT(all_stats[0].rtt_avg_ms, rtt1);
-    EXPECT_LT(all_stats[0].rtt_avg_ms, rtt2);
+    EXPECT_GT(all_stats[0].rtt_avg_us, rtt1);
+    EXPECT_LT(all_stats[0].rtt_avg_us, rtt2);
 }
 
 // Flush thresholds
@@ -313,10 +313,10 @@ TEST_F(StatisticsManagerTest, MultiplePeersMaintainIndependentStats)
     // Independent validations
     EXPECT_EQ(stats1.packets_rx, 1);
     EXPECT_EQ(stats1.packets_sent, 0);
-    EXPECT_EQ(stats1.rtt_avg_ms, 0);
+    EXPECT_EQ(stats1.rtt_avg_us, 0);
 
     EXPECT_EQ(stats2.packets_rx, 0);
-    EXPECT_EQ(stats2.rtt_avg_ms, 30);
+    EXPECT_EQ(stats2.rtt_avg_us, 30);
 }
 
 TEST_F(StatisticsManagerTest, InitLoadsPersistedStats)
@@ -329,7 +329,7 @@ TEST_F(StatisticsManagerTest, InitLoadsPersistedStats)
     persisted.packets_rx = 50;
     persisted.packets_sent = 40;
     persisted.packets_lost = 2;
-    persisted.rtt_avg_ms = 15;
+    persisted.rtt_avg_us = 15;
 
     etl::vector<PeerStatisticsPersist, MAX_PEERS> persisted_list;
     persisted_list.push_back(persisted);
@@ -354,7 +354,7 @@ TEST_F(StatisticsManagerTest, InitLoadsPersistedStats)
     EXPECT_EQ(stats.node_id, node_id);
     EXPECT_EQ(stats.rssi_avg, -55);
     EXPECT_EQ(stats.packets_rx, 50);
-    EXPECT_EQ(stats.rtt_avg_ms, 15);
+    EXPECT_EQ(stats.rtt_avg_us, 15);
 }
 
 TEST_F(StatisticsManagerTest, SyncPeersRemovesOrphanEntry)

--- a/host_test/test_storage_manager/main/test_storage_manager.cpp
+++ b/host_test/test_storage_manager/main/test_storage_manager.cpp
@@ -104,7 +104,7 @@ static etl::vector<PeerStatisticsPersist, MAX_PEERS * 2> create_test_stats(int c
         s.packets_rx = 100 + i;
         s.packets_sent = 90 + i;
         s.packets_lost = 5 + i;
-        s.rtt_avg_ms = 10 + i;
+        s.rtt_avg_us = 10 + i;
         stats.push_back(s);
     }
     return stats;

--- a/host_test/test_tx_manager/main/test_tx_manager.cpp
+++ b/host_test/test_tx_manager/main/test_tx_manager.cpp
@@ -5,6 +5,7 @@
 #include "mock_en_hal_espnow.hpp"
 #include "mock_message_codec.hpp"
 #include "mock_en_hal_freertos.hpp"
+#include "mock_en_hal_timer.hpp"
 #include "mock_statistics_manager.hpp"
 #include "mock_peer_manager.hpp"
 #include "tx_manager.hpp"
@@ -23,6 +24,7 @@ protected:
     NiceMock<MockTxStateMachine> fsm;
     NiceMock<MockEspNowHAL> hal;
     NiceMock<MockFreeRTOSHAL> freertos_hal;
+    NiceMock<MockTimerHAL> timer;
     NiceMock<MockMessageCodec> codec;
     NiceMock<MockStatisticsManager> stats;
     NiceMock<MockPeerManager> peer_mgr;
@@ -57,7 +59,7 @@ protected:
         ON_CALL(freertos_hal, queue_delete(_)).WillByDefault(Return());
         ON_CALL(freertos_hal, timer_delete(_, _)).WillByDefault(Return(pdPASS));
 
-        manager = std::make_unique<TxManager>(fsm, hal, freertos_hal, codec, stats, peer_mgr);
+        manager = std::make_unique<TxManager>(fsm, hal, freertos_hal, timer, codec, stats, peer_mgr);
     }
 
     void deinit_after_init()
@@ -288,7 +290,7 @@ TEST_F(TxManagerTest, HandleAckUpdateStats)
     ack_packet.header.msg_type = MessageType::ACK;
     ack_packet.header.sequence_number = 42; // Matches pending ACK
     ack_packet.header.ack_status = AckStatus::OK;
-    ack_packet.raw.timestamp_ms = 100;
+    ack_packet.raw.timestamp_us = 100;
 
     // Stats update expected on success status
     EXPECT_CALL(stats, on_ack_received(pending.node_id, 100)).Times(1);

--- a/host_test/test_tx_manager/main/test_tx_manager_task.cpp
+++ b/host_test/test_tx_manager/main/test_tx_manager_task.cpp
@@ -9,6 +9,7 @@
 #include "mock_discovery_manager.hpp"
 #include "mock_statistics_manager.hpp"
 #include "mock_peer_manager.hpp"
+#include "mock_en_hal_timer.hpp"
 #include "hal_real_freertos.hpp"
 #include "tx_manager.hpp"
 using namespace espnow;
@@ -32,6 +33,7 @@ protected:
     // Owned pointers to correct destruction and no mock leakage on tests
     std::unique_ptr<NiceMock<MockTxStateMachine>> fsm_owned;
     std::unique_ptr<NiceMock<MockEspNowHAL>> hal_owned;
+    std::unique_ptr<NiceMock<MockTimerHAL>> hal_timer_owned;
     std::unique_ptr<NiceMock<MockMessageCodec>> codec_owned;
     std::unique_ptr<NiceMock<MockStatisticsManager>> statistics_mgr_owned;
     std::unique_ptr<NiceMock<MockPeerManager>> peer_mgr_owned;
@@ -39,6 +41,7 @@ protected:
     // Raw pointers to use in tests
     NiceMock<MockTxStateMachine>* fsm;
     NiceMock<MockEspNowHAL>* hal;
+    NiceMock<MockTimerHAL>* hal_timer;
     NiceMock<MockMessageCodec>* codec;
     NiceMock<MockStatisticsManager>* statistics_mgr;
     NiceMock<MockPeerManager>* peer_mgr;
@@ -58,12 +61,14 @@ protected:
     {
         fsm_owned = std::make_unique<NiceMock<MockTxStateMachine>>();
         hal_owned = std::make_unique<NiceMock<MockEspNowHAL>>();
+        hal_timer_owned = std::make_unique<NiceMock<MockTimerHAL>>();
         codec_owned = std::make_unique<NiceMock<MockMessageCodec>>();
         statistics_mgr_owned = std::make_unique<NiceMock<MockStatisticsManager>>();
         peer_mgr_owned = std::make_unique<NiceMock<MockPeerManager>>();
 
         fsm = fsm_owned.get();
         hal = hal_owned.get();
+        hal_timer = hal_timer_owned.get();
         codec = codec_owned.get();
         statistics_mgr = statistics_mgr_owned.get();
         peer_mgr = peer_mgr_owned.get();
@@ -115,7 +120,7 @@ protected:
         }));
 
         manager = std::make_unique<TxManager>(
-            *fsm_owned, *hal_owned, freertos_hal, *codec_owned, *statistics_mgr_owned, *peer_mgr_owned);
+            *fsm_owned, *hal_owned, freertos_hal, *hal_timer_owned, *codec_owned, *statistics_mgr_owned, *peer_mgr_owned);
     }
 
     void TearDown() override
@@ -197,7 +202,7 @@ protected:
         pkt.header.msg_type = MessageType::ACK;
         pkt.header.ack_status = AckStatus::OK;
         pkt.header.sequence_number = pending_ack.has_value() ? pending_ack->sequence_number : 0;
-        pkt.raw.timestamp_ms = 0;
+        pkt.raw.timestamp_us = 0;
         return pkt;
     }
 

--- a/include/espnow_types.hpp
+++ b/include/espnow_types.hpp
@@ -63,7 +63,7 @@ struct RxPacket
     uint8_t data[ESP_NOW_MAX_DATA_LEN]; /**< Raw payload data */
     size_t len;                         /**< Length of the payload in bytes */
     int8_t rssi;                        /**< Received Signal Strength Indicator (dBm) */
-    int64_t timestamp_ms;               /**< Millisecond timestamp (esp_timer_get_time / 1000) */
+    int64_t timestamp_us;               /**< Microsecond timestamp (esp_timer_get_time) */
 };
 
 /**
@@ -166,7 +166,7 @@ enum class NodeState
 struct PendingAck
 {
     uint16_t sequence_number; /**< Sequence number of the message being tracked */
-    int64_t timestamp_ms;     /**< Timestamp of the last attempt (ms) */
+    int64_t timestamp_us;     /**< Timestamp of the last attempt (us) */
     uint8_t retries_left;     /**< Remaining retransmission attempts */
     TxPacket packet;          /**< Copy of the packet to allow retransmission */
     NodeId node_id;           /**< Target Node ID for tracking and timeout logic */
@@ -187,8 +187,8 @@ struct PeerStatistics
     uint32_t delivery_failures = 0; ///< ESP-NOW callback reported ESP_NOW_SEND_FAIL
     uint32_t packets_lost = 0;      ///< Number of packets lost (ACK timeout after retries)
     uint32_t retries = 0;           ///< Number of retries
-    uint32_t rtt_last_ms = 0;       ///< Last round-trip time in milliseconds
-    uint32_t rtt_avg_ms = 0;        ///< Average round-trip time in milliseconds (0 = unknown)
+    uint32_t rtt_last_us = 0;       ///< Last round-trip time in microseconds
+    uint32_t rtt_avg_us = 0;        ///< Average round-trip time in microseconds (0 = unknown)
 };
 
 /**
@@ -204,7 +204,7 @@ struct PeerStatisticsPersist
     uint32_t delivery_failures = 0; ///< ESP-NOW callback reported ESP_NOW_SEND_FAIL
     uint32_t packets_lost = 0;      ///< Number of packets lost (ACK timeout after retries)
     uint32_t retries = 0;           ///< Number of retries
-    uint32_t rtt_avg_ms = 0;        ///< Average round-trip time in milliseconds
+    uint32_t rtt_avg_us = 0;        ///< Average round-trip time in microseconds
 };
 
 /**

--- a/include/interfaces/i_statistics_manager.hpp
+++ b/include/interfaces/i_statistics_manager.hpp
@@ -111,9 +111,9 @@ public:
      * threshold is reached.
      *
      * @param node_id The unique identifier of the peer node that sent the ACK.
-     * @param rtt_ms The round-trip time in milliseconds.
+     * @param rtt_us The round-trip time in microseconds.
      */
-    virtual void on_ack_received(NodeId node_id, uint32_t rtt_ms) = 0;
+    virtual void on_ack_received(NodeId node_id, uint32_t rtt_us) = 0;
 
     // --- Tx delivery events (called from tx_task via callback) ---
 

--- a/include/statistics_manager.hpp
+++ b/include/statistics_manager.hpp
@@ -62,7 +62,7 @@ public:
     void on_packet_received(NodeId node_id, int8_t rssi) override;
 
     /** @copydoc IStatisticsManager::on_ack_received */
-    void on_ack_received(NodeId node_id, uint32_t rtt_ms) override;
+    void on_ack_received(NodeId node_id, uint32_t rtt_us) override;
 
     /** @copydoc IStatisticsManager::on_delivery_success */
     void on_delivery_success(NodeId node_id) override;

--- a/include/storage_manager.hpp
+++ b/include/storage_manager.hpp
@@ -112,7 +112,7 @@ struct PersistentStats
             if (stats[i].node_id != other.stats[i].node_id || stats[i].rssi_avg != other.stats[i].rssi_avg ||
                 stats[i].packets_rx != other.stats[i].packets_rx || stats[i].packets_sent != other.stats[i].packets_sent ||
                 stats[i].packets_lost != other.stats[i].packets_lost ||
-                stats[i].rtt_avg_ms != other.stats[i].rtt_avg_ms) {
+                stats[i].rtt_avg_us != other.stats[i].rtt_avg_us) {
                 return false;
             }
         }

--- a/include/tx_manager.hpp
+++ b/include/tx_manager.hpp
@@ -3,6 +3,7 @@
 
 #include "i_en_hal_espnow.hpp"
 #include "i_en_hal_freertos.hpp"
+#include "i_en_hal_timer.hpp"
 #include "i_message_codec.hpp"
 #include "i_tx_manager.hpp"
 #include "i_tx_state_machine.hpp"
@@ -17,6 +18,7 @@ public:
         ITxStateMachine& fsm,
         IEspNowHAL& hal_espnow,
         IFreeRTOSHAL& freertos_hal,
+        ITimerHAL& hal_timer,
         IMessageCodec& codec,
         IStatisticsManager& stats_mgr,
         IPeerManager& peer_mgr);
@@ -52,6 +54,7 @@ private:
     IEspNowHAL& hal_espnow_;
     IMessageCodec& codec_;
     IFreeRTOSHAL& freertos_hal_;
+    ITimerHAL& hal_timer_;
     IStatisticsManager& stats_mgr_;
     IPeerManager& peer_mgr_;
 

--- a/src/espnow_manager.cpp
+++ b/src/espnow_manager.cpp
@@ -73,7 +73,7 @@ EspNowManager& EspNowManager::instance()
     static auto stats_mgr = std::make_unique<StatisticsManager>(*storage, *hal_freertos);
     static auto tx_fsm = std::make_unique<TxStateMachine>();
     static auto tx_manager =
-        std::make_unique<TxManager>(*tx_fsm, *hal_espnow, *hal_freertos, *message_codec, *stats_mgr, *peer_manager);
+        std::make_unique<TxManager>(*tx_fsm, *hal_espnow, *hal_freertos, *hal_timer, *message_codec, *stats_mgr, *peer_manager);
     static auto heartbeat_mgr = std::make_unique<HeartbeatManager>(*tx_manager, *peer_manager, *hal_timer);
     static auto pairing_mgr = std::make_unique<PairingManager>(*tx_manager, *peer_manager, *hal_freertos, *hal_timer);
     static auto message_router = std::make_unique<MessageRouter>(*scanner, *tx_manager, *heartbeat_mgr, *pairing_mgr);
@@ -503,8 +503,8 @@ void EspNowManager::esp_now_recv_cb(const esp_now_recv_info_t* info, const uint8
     memcpy(packet.data, data, len);
     packet.len = len;
     packet.rssi = static_cast<int8_t>(info->rx_ctrl->rssi);
-    // Raw timestamp in us, will be converted to ms in rx_task
-    packet.timestamp_ms = self->hal_timer_->get_time_us();
+    // Raw microsecond timestamp
+    packet.timestamp_us = self->hal_timer_->get_time_us();
     self->hal_freertos_->queue_send_fromISR(self->rx_queue_handle_, &packet, 0);
 }
 
@@ -553,9 +553,6 @@ void EspNowManager::rx_task(void* arg)
 
         // Wait for incoming packets with a timeout to periodically check for notifications and tick managers.
         if (self->hal_freertos_->queue_receive(self->rx_queue_handle_, &packet, pdMS_TO_TICKS(100)) == pdTRUE) {
-            // Convert raw timestamp from us to ms
-            packet.timestamp_ms /= 1000;
-
             // Validate CRC
             if (self->message_codec_->validate_crc(packet.data, packet.len)) {
                 // Decode header

--- a/src/statistics_manager.cpp
+++ b/src/statistics_manager.cpp
@@ -40,7 +40,7 @@ esp_err_t StatisticsManager::init()
             entry.stats.packets_rx = p.packets_rx;
             entry.stats.packets_sent = p.packets_sent;
             entry.stats.packets_lost = p.packets_lost;
-            entry.stats.rtt_avg_ms = p.rtt_avg_ms;
+            entry.stats.rtt_avg_us = p.rtt_avg_us;
             entry.stats.retries = p.retries;
             entries_.push_back(entry);
         }
@@ -144,19 +144,19 @@ void StatisticsManager::on_packet_received(NodeId node_id, int8_t rssi)
     }
 }
 
-void StatisticsManager::on_ack_received(NodeId node_id, uint32_t rtt_ms)
+void StatisticsManager::on_ack_received(NodeId node_id, uint32_t rtt_us)
 {
     std::optional<etl::vector<PeerStatisticsPersist, MAX_PEERS>> snapshot;
 
     if (hal_freertos_.semaphore_take(mutex_, pdMS_TO_TICKS(5)) == pdTRUE) {
         auto entry = find_entry(node_id);
         if (entry != nullptr) {
-            entry->stats.rtt_last_ms = rtt_ms;
-            if (entry->stats.rtt_avg_ms == 0) {
-                entry->stats.rtt_avg_ms = rtt_ms;
+            entry->stats.rtt_last_us = rtt_us;
+            if (entry->stats.rtt_avg_us == 0) {
+                entry->stats.rtt_avg_us = rtt_us;
             }
             else {
-                entry->stats.rtt_avg_ms = update_ema_u32(entry->stats.rtt_avg_ms, rtt_ms, RTT_EMA_ALPHA);
+                entry->stats.rtt_avg_us = update_ema_u32(entry->stats.rtt_avg_us, rtt_us, RTT_EMA_ALPHA);
             }
             entry->dirty_rtt++;
             snapshot = maybe_build_flush_snapshot(*entry);
@@ -394,7 +394,7 @@ etl::vector<PeerStatisticsPersist, MAX_PEERS> StatisticsManager::build_persist_s
         p.driver_errors = entry.stats.driver_errors;
         p.delivery_failures = entry.stats.delivery_failures;
         p.packets_lost = entry.stats.packets_lost;
-        p.rtt_avg_ms = entry.stats.rtt_avg_ms;
+        p.rtt_avg_us = entry.stats.rtt_avg_us;
         p.retries = entry.stats.retries;
         snapshot.push_back(p);
     }

--- a/src/tx_manager.cpp
+++ b/src/tx_manager.cpp
@@ -12,6 +12,7 @@ TxManager::TxManager(
     ITxStateMachine& fsm,
     IEspNowHAL& hal_espnow,
     IFreeRTOSHAL& freertos_hal,
+    ITimerHAL& hal_timer,
     IMessageCodec& codec,
     IStatisticsManager& stats_mgr,
     IPeerManager& peer_mgr)
@@ -19,6 +20,7 @@ TxManager::TxManager(
     , hal_espnow_(hal_espnow)
     , codec_(codec)
     , freertos_hal_(freertos_hal)
+    , hal_timer_(hal_timer)
     , stats_mgr_(stats_mgr)
     , peer_mgr_(peer_mgr)
     , sequence_counter_(0)
@@ -240,9 +242,9 @@ void TxManager::handle_ack(const DecodedRxPacket& decoded)
         return;
     }
 
-    // Calculate RTT: current packet timestamp (ms) - pending packet timestamp (ms)
-    uint32_t rtt_ms = static_cast<uint32_t>(decoded.raw.timestamp_ms - pending_ack->timestamp_ms);
-    stats_mgr_.on_ack_received(pending_ack->node_id, rtt_ms);
+    // Calculate RTT: current packet timestamp (us) - pending packet timestamp (us)
+    uint32_t rtt_us = static_cast<uint32_t>(decoded.raw.timestamp_us - pending_ack->timestamp_us);
+    stats_mgr_.on_ack_received(pending_ack->node_id, rtt_us);
 
     notify_logical_ack();
 }
@@ -317,7 +319,7 @@ void TxManager::tx_task()
                     if (next == TxState::WAITING_FOR_ACK) {
                         PendingAck pending = {
                             .sequence_number = structured_packet.header.sequence_number,
-                            .timestamp_ms = structured_packet.header.timestamp_ms,
+                            .timestamp_us = hal_timer_.get_time_us(),
                             .retries_left = 3,
                             .packet = raw_packet,
                             .node_id = structured_packet.header.dest_node_id};

--- a/test_apps/field_range_test/node/main/main.cpp
+++ b/test_apps/field_range_test/node/main/main.cpp
@@ -274,7 +274,7 @@ extern "C" void app_main(void)
             draw_text(frame_buffer, 0, 16, buf);
 
             snprintf(
-                buf, sizeof(buf), "RTT:%lu AVG:%lu", (unsigned long)stats.rtt_last_ms, (unsigned long)stats.rtt_avg_ms);
+                buf, sizeof(buf), "RTT:%lu AVG:%lu", (unsigned long)stats.rtt_last_us, (unsigned long)stats.rtt_avg_us);
             draw_text(frame_buffer, 0, 32, buf);
 
             ESP_LOGI(
@@ -284,8 +284,8 @@ extern "C" void app_main(void)
                 stats.rssi_avg,
                 (unsigned long)stats.packets_sent,
                 (unsigned long)stats.packets_lost,
-                (unsigned long)stats.rtt_last_ms,
-                (unsigned long)stats.rtt_avg_ms);
+                (unsigned long)stats.rtt_last_us,
+                (unsigned long)stats.rtt_avg_us);
         }
         else {
             draw_text(frame_buffer, 0, 0, "WAITING HUB...");


### PR DESCRIPTION
- Update PeerStatistics and PeerStatisticsPersist fields from rtt_last_ms/rtt_avg_ms to rtt_last_us/rtt_avg_us
- Inject ITimerHAL into TxManager to capture microsecond transmit timestamp in tx_task
- Preserve raw microsecond timestamps in RxPacket and calculate RTT in microseconds
- Update host test suites, mocks, and API documentation